### PR TITLE
update implementation of injectable

### DIFF
--- a/examples/typescript/index.tsx
+++ b/examples/typescript/index.tsx
@@ -2,17 +2,19 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import { DiProvider, di, withDi, injectable } from 'react-magnetic-di';
 
-const useStateDi = injectable(useState, () => useState(true));
+const useOpen = () => useState(false);
+
+const useOpenDi = injectable(useOpen, () => useState(true));
 
 const MyComponent = () => {
-  di(useState);
-  const [open, setOpen] = useState(false);
+  di(useOpen);
+  const [open, setOpen] = useOpen();
   return (
     <button onClick={() => setOpen(!open)}>{open ? 'open' : 'closed'}</button>
   );
 };
 
-const MyComponentWithDi = withDi(MyComponent, [useStateDi]);
+const MyComponentWithDi = withDi(MyComponent, [useOpenDi]);
 
 /**
  * Main App
@@ -23,7 +25,7 @@ const App = () => (
     <main>
       <MyComponent />
       <hr />
-      <DiProvider use={[useStateDi]}>
+      <DiProvider use={[useOpenDi]}>
         <MyComponent />
       </DiProvider>
       <hr />

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,24 @@ declare module 'react-magnetic-di' {
 
   type Dependency = Function;
 
+  export type DeepPartial<Type> = Type extends DeepPartialFunction<Type>
+    ? DeepPartialFunction<Type>
+    : Type extends Array<infer InferredArrayMember>
+    ? DeepPartialArray<InferredArrayMember>
+    : Type extends object
+    ? DeepPartialObject<Type>
+    : Type | undefined;
+
+  interface DeepPartialArray<Type> extends Array<DeepPartial<Type>> {}
+
+  type DeepPartialObject<Type> = {
+    [Key in keyof Type]?: DeepPartial<Type[Key]>;
+  };
+
+  type DeepPartialFunction<Type> = Type extends (...args: any) => any
+    ? (...args: Parameters<Type>) => DeepPartialObject<ReturnType<Type>>
+    : Type;
+
   class DiProvider extends Component<
     {
       use: Dependency[];
@@ -21,7 +39,7 @@ declare module 'react-magnetic-di' {
   /** @deprecated use injectable instead */
   function mock<T extends Dependency>(original: T, mock: T): T;
 
-  function injectable<T extends Dependency>(from: T, implementation: T): T;
+  function injectable<T extends Dependency>(from: T, implementation: DeepPartial<T>): T;
 
   function di(...dependencies: Dependency[]): void;
   /** allow using di without Babel */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,23 +3,19 @@ declare module 'react-magnetic-di' {
 
   type Dependency = Function;
 
-  export type DeepPartial<Type> = Type extends DeepPartialFunction<Type>
-    ? DeepPartialFunction<Type>
-    : Type extends Array<infer InferredArrayMember>
-    ? DeepPartialArray<InferredArrayMember>
+  type DeepPartial<Type> = Type extends (...args: any) => any
+    ? (...args: Parameters<Type>) => DeepPartial<ReturnType<Type>>
+    : Type extends ReadonlyArray<infer InferredArrayMember>
+    ? InferredArrayMember[] extends Type
+      ? Array<DeepPartial<InferredArrayMember>> // list
+      : DeepPartialObject<Type> // tuple
     : Type extends object
     ? DeepPartialObject<Type>
     : Type | undefined;
 
-  interface DeepPartialArray<Type> extends Array<DeepPartial<Type>> {}
-
   type DeepPartialObject<Type> = {
     [Key in keyof Type]?: DeepPartial<Type[Key]>;
   };
-
-  type DeepPartialFunction<Type> = Type extends (...args: any) => any
-    ? (...args: Parameters<Type>) => DeepPartialObject<ReturnType<Type>>
-    : Type;
 
   class DiProvider extends Component<
     {
@@ -39,7 +35,10 @@ declare module 'react-magnetic-di' {
   /** @deprecated use injectable instead */
   function mock<T extends Dependency>(original: T, mock: T): T;
 
-  function injectable<T extends Dependency>(from: T, implementation: DeepPartial<T>): T;
+  function injectable<T extends Dependency>(
+    from: T,
+    implementation: DeepPartial<T>
+  ): T;
 
   function di(...dependencies: Dependency[]): void;
   /** allow using di without Babel */


### PR DESCRIPTION
Motivation: 
When creating mocks especially when we are mocking `react hooks`(or to be precise hook return values) we don't need every field in our test
Here is an one of examples that i was implementing earlier , from project context in my test i only needed `projectId` and `projectName`, but still i needed to pass all other fields. I know i could make `data` field partial as well but here how ugly typescript code comes in.
before:
```
injectable<() => Partial<ReturnType<typeof useProjectContext>>>(useProjectContext, () => ({
        data: {
            projectId: 10001,
            projectName: 'TM-1',
            projectType: 'business',
            isProjectAdmin: true,
            projectKey: 'TM-1',
            projectUuid: 'uuid',
            simplified: false,
            isProjectArchived: null,
        },
    })),
```
 after:

```
injectable(useProjectContext, () => ({
        data: {
            projectId: 10001,
            projectName: 'TM-1'
        },
    })),
```
As one more argument: 
There a lot of `@ts-ignore`
around the codebase just search `injectable(use*` 