### PR TITLE
Add simple type identity overload for injectable

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,6 +49,7 @@ declare module 'react-magnetic-di' {
   /** @deprecated use injectable instead */
   function mock<T extends Dependency>(original: T, mock: T): T;
 
+  function injectable<T extends Dependency>(from: T, implementation: T): T;
   function injectable<T extends Dependency>(
     from: T,
     implementation: ComponentOrFunction<T>


### PR DESCRIPTION
Make type infer faster and prevent some issues with partial of circular types by providing a plain identity overload
Thanks @theKashey 