### PR TITLE
Support react-test-renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-test-renderer": "^18.2.0",
         "typescript": "^4.9.3",
         "webpack": "^4.46.0",
         "webpack-cli": "^3.3.12",
@@ -14844,6 +14845,42 @@
       "version": "17.0.2",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true,
       "license": "MIT"
     },
@@ -30111,6 +30148,35 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA=",
       "dev": true
+    },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dev": true,
+      "requires": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        }
+      }
     },
     "readable-stream": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
     "typescript": "^4.9.3",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",

--- a/src/react/__tests__/common.js
+++ b/src/react/__tests__/common.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import { di, injectable } from '../../index';
+
+export const Wrapper = ({ children }) => <wrapper-og>{children}</wrapper-og>;
+export const Text = () => <text-og />;
+
+export class Label extends Component {
+  render() {
+    const [_Wrapper, _Text] = di([Wrapper, Text], Label);
+    return (
+      <label-og>
+        <_Wrapper>
+          <_Text />
+        </_Wrapper>
+      </label-og>
+    );
+  }
+}
+
+export class Input extends Component {
+  render() {
+    const [_Text] = di([Text], Input);
+    return (
+      <input-og>
+        <_Text />
+      </input-og>
+    );
+  }
+}
+
+export const TextDi = injectable(Text, () => <text-di />);
+export const WrapperDi = injectable(Wrapper, ({ children }) => (
+  <wrapper-di>{children}</wrapper-di>
+));

--- a/src/react/__tests__/integration-rtl.test.js
+++ b/src/react/__tests__/integration-rtl.test.js
@@ -1,0 +1,126 @@
+/** @jest-environment jsdom */
+/* eslint-env jest */
+
+import React, { Fragment } from 'react';
+import { render } from '@testing-library/react';
+import { DiProvider, withDi, injectable } from '../../index';
+import { Label, Input, Text, TextDi, WrapperDi } from './common';
+
+describe('Integration: testing-library', () => {
+  it('should return real dependencies if provider-less', () => {
+    const { container } = render(
+      <Fragment>
+        <Label />
+        <Input />
+      </Fragment>
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <label-og>
+          <wrapper-og>
+            <text-og />
+          </wrapper-og>
+        </label-og>
+        <input-og>
+          <text-og />
+        </input-og>
+      </div>
+    `);
+  });
+
+  it('should override all dependencies of same type', () => {
+    const { container } = render(
+      <DiProvider use={[TextDi]}>
+        <Label />
+        <Input />
+      </DiProvider>
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <label-og>
+          <wrapper-og>
+            <text-di />
+          </wrapper-og>
+        </label-og>
+        <input-og>
+          <text-di />
+        </input-og>
+      </div>
+    `);
+  });
+
+  it('should allow override composition', () => {
+    const { container } = render(
+      <DiProvider use={[WrapperDi]}>
+        <DiProvider use={[TextDi]}>
+          <Label />
+          <Input />
+        </DiProvider>
+      </DiProvider>
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <label-og>
+          <wrapper-di>
+            <text-di />
+          </wrapper-di>
+        </label-og>
+        <input-og>
+          <text-di />
+        </input-og>
+      </div>
+    `);
+  });
+
+  it('should only override dependencies of specified target', () => {
+    const { container } = render(
+      <DiProvider target={[Input]} use={[WrapperDi]}>
+        <DiProvider target={Label} use={[TextDi]}>
+          <Label />
+          <Input />
+        </DiProvider>
+      </DiProvider>
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <label-og>
+          <wrapper-og>
+            <text-di />
+          </wrapper-og>
+        </label-og>
+        <input-og>
+          <text-og />
+        </input-og>
+      </div>
+    `);
+  });
+
+  it('should get closest dependency if multiple providers using same type', () => {
+    const TextDi2 = injectable(Text, () => <text-di2 />);
+    TextDi2.displayName = 'di(Text2)';
+    const WrappedInput = withDi(Input, [TextDi2]);
+    const { container } = render(
+      <DiProvider use={[TextDi]}>
+        <Label />
+        <WrappedInput />
+      </DiProvider>
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <label-og>
+          <wrapper-og>
+            <text-di />
+          </wrapper-og>
+        </label-og>
+        <input-og>
+          <text-di2 />
+        </input-og>
+      </div>
+    `);
+  });
+});

--- a/src/react/__tests__/integration-rtr.test.js
+++ b/src/react/__tests__/integration-rtr.test.js
@@ -1,158 +1,124 @@
-/**
- * @jest-environment jsdom
- */
 /* eslint-env jest */
+import React, { Fragment } from 'react';
+import { create } from 'react-test-renderer';
+import { DiProvider, withDi, injectable } from '../../index';
+import { Label, Input, Text, TextDi, WrapperDi } from './common';
 
-import React, { Component, Fragment } from 'react';
-import { render } from '@testing-library/react';
-import { di, DiProvider, withDi, injectable } from '../../index';
-
-const Wrapper = ({ children }) => <wrapper-og>{children}</wrapper-og>;
-const Text = () => <text-og />;
-
-class Label extends Component {
-  render() {
-    const [_Wrapper, _Text] = di([Wrapper, Text], Label);
-    return (
-      <label-og>
-        <_Wrapper>
-          <_Text />
-        </_Wrapper>
-      </label-og>
-    );
-  }
-}
-
-class Input extends Component {
-  render() {
-    const [_Text] = di([Text], Input);
-    return (
-      <input-og>
-        <_Text />
-      </input-og>
-    );
-  }
-}
-
-const TextDi = injectable(Text, () => <text-di />);
-const WrapperDi = injectable(Wrapper, ({ children }) => (
-  <wrapper-di>{children}</wrapper-di>
-));
-
-describe('Integration', () => {
+describe('Integration: react-test-renderer', () => {
   it('should return real dependencies if provider-less', () => {
-    const { container } = render(
+    const tree = create(
       <Fragment>
         <Label />
         <Input />
       </Fragment>
-    );
+    ).toJSON();
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
+    expect(tree).toMatchInlineSnapshot(`
+      [
         <label-og>
           <wrapper-og>
             <text-og />
           </wrapper-og>
-        </label-og>
+        </label-og>,
         <input-og>
           <text-og />
-        </input-og>
-      </div>
+        </input-og>,
+      ]
     `);
   });
 
   it('should override all dependencies of same type', () => {
-    const { container } = render(
+    const tree = create(
       <DiProvider use={[TextDi]}>
         <Label />
         <Input />
       </DiProvider>
-    );
+    ).toJSON();
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
+    expect(tree).toMatchInlineSnapshot(`
+      [
         <label-og>
           <wrapper-og>
             <text-di />
           </wrapper-og>
-        </label-og>
+        </label-og>,
         <input-og>
           <text-di />
-        </input-og>
-      </div>
+        </input-og>,
+      ]
     `);
   });
 
   it('should allow override composition', () => {
-    const { container } = render(
+    const tree = create(
       <DiProvider use={[WrapperDi]}>
         <DiProvider use={[TextDi]}>
           <Label />
           <Input />
         </DiProvider>
       </DiProvider>
-    );
+    ).toJSON();
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
+    expect(tree).toMatchInlineSnapshot(`
+      [
         <label-og>
           <wrapper-di>
             <text-di />
           </wrapper-di>
-        </label-og>
+        </label-og>,
         <input-og>
           <text-di />
-        </input-og>
-      </div>
+        </input-og>,
+      ]
     `);
   });
 
   it('should only override dependencies of specified target', () => {
-    const { container } = render(
+    const tree = create(
       <DiProvider target={[Input]} use={[WrapperDi]}>
         <DiProvider target={Label} use={[TextDi]}>
           <Label />
           <Input />
         </DiProvider>
       </DiProvider>
-    );
+    ).toJSON();
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
+    expect(tree).toMatchInlineSnapshot(`
+      [
         <label-og>
           <wrapper-og>
             <text-di />
           </wrapper-og>
-        </label-og>
+        </label-og>,
         <input-og>
           <text-og />
-        </input-og>
-      </div>
+        </input-og>,
+      ]
     `);
   });
 
   it('should get closest dependency if multiple providers using same type', () => {
     const TextDi2 = injectable(Text, () => <text-di2 />);
+    TextDi2.displayName = 'di(Text2)';
     const WrappedInput = withDi(Input, [TextDi2]);
-    const { container } = render(
+    const tree = create(
       <DiProvider use={[TextDi]}>
         <Label />
         <WrappedInput />
       </DiProvider>
-    );
+    ).toJSON();
 
-    expect(container).toMatchInlineSnapshot(`
-      <div>
+    expect(tree).toMatchInlineSnapshot(`
+      [
         <label-og>
           <wrapper-og>
             <text-di />
           </wrapper-og>
-        </label-og>
+        </label-og>,
         <input-og>
           <text-di2 />
-        </input-og>
-      </div>
+        </input-og>,
+      ]
     `);
   });
 });

--- a/src/react/consumer.js
+++ b/src/react/consumer.js
@@ -5,9 +5,13 @@ import { warnOnce, mock } from './utils';
 function di(deps, target) {
   // check if babel plugin has been added
   if (Array.isArray(deps)) {
-    // Read context and grab all the dependencies override
-    // from all Providers in the tree
-    const { getDependencies = (v) => v } = Context._currentValue || {};
+    // Read context and grab all the dependencies override Providers in the tree
+    const { getDependencies = (v) => v } =
+      // grab value from alt renderer (eg react-test-renderer)
+      (Context._currentRenderer2 && Context._currentValue2) ||
+      // grab value from default renderer
+      Context._currentValue ||
+      {};
     return getDependencies(deps, target);
   } else {
     warnOnce(


### PR DESCRIPTION
Seems like `react-test-renderer` uses the "alternative" renderer code path to share current context values. So we check them first if a second renderer is running, falling back to primary renderer if not

Closes #62 