### PR TITLE
Fix eslint rule for recursive components

### DIFF
--- a/src/eslint/rules/__tests__/exaustive-inject.test.js
+++ b/src/eslint/rules/__tests__/exaustive-inject.test.js
@@ -140,6 +140,42 @@ ruleTester.run('exhaustive-inject', rule, {
       `,
       options: [{ ignore: ['useQuery'] }],
     },
+    // it should ignore recursive components
+    `
+        import { Suspense, useState, useMemo } from 'react';
+        import { di } from 'react-magnetic-di';
+  
+        function MyComponent({ child }) {
+          di(useState);
+          useState();
+          useMemo();
+          return <MyComponent child={child} />
+        }
+      `,
+    // it should ignore recursive arrow function components
+    `
+        import { Suspense, useState, useMemo } from 'react';
+        import { di } from 'react-magnetic-di';
+  
+        const MyComponent = ({ child }) => {
+          di(useState);
+          useState();
+          useMemo();
+          return <MyComponent child={child} />
+        };
+      `,
+    // it should ignore recursive hooks
+    `
+        import { Suspense, useState } from 'react';
+        import { di } from 'react-magnetic-di';
+  
+        const useX = ({ child }) => {
+          di(useState);
+          useState();
+          if (!child.child) return null;
+          return useX(child.child)
+        };
+      `,
   ],
 
   invalid: [


### PR DESCRIPTION
Recursive components current report as errors, but when auto-fixed don't work correctly.

This commit keeps track of the current component/function name stack and ignores adding any of them into the `di` call statement. Stacking addresses the following use cases:
```
function MenuRenderer({ menu }) {
    const renderSubMenu = (subMenu) => <MenuRenderer menu={subMenu} key={subMenu.id} />;

    return (
       <div>
           {menu.name}
           {menu.subMenus.map(renderSubMenu)}
       </div>
    );
}
```

Here we should see a stack going: `[] => [MenuRenderer] => [MenuRenderer, renderSubMenu] => [MenuRenderer] => []`.

I can't think of a case where any member of these stacks should be added to the dependencies list, although there's no control of what is getting tracked in the stack (can be a component, nested function, renderProp, etc.).