### PR TITLE
Add runWithDi feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/84136/83958267-1c8f7f00-a8b3-11ea-9725-1d3530af5f8d.png" alt="react-magnetic-di logo" height="150" />
+  <img src="https://user-images.githubusercontent.com/84136/83958267-1c8f7f00-a8b3-11ea-9725-1d3530af5f8d.png" alt="magnetic-di logo" height="150" />
 </p>
 <h1 align="center">magnetic-di</h1>
 <p align="center">
@@ -178,10 +178,10 @@ export async function myApiFetcher() {
 }
 ```
 
-In the tests, you can use either `globalDi` directly or the wrapper `runWithDi`. The main difference is that `runWithDi` will clear the replacements for you after function execution is terminated. Such util also handles async code, but might not work effectively with scheduled code paths, or event driven implementations. In those scenarios we recommend manually adding `globalDi.clear()` to `afterEach` to ensure there is no pollution between tests.
+In the tests, you can use `runWithDi`, which will setup and clear the replacements for you after function execution is terminated. Such util also handles async code, but might require you to wrap the entire test to work effectively with scheduled code paths, or event driven implementations.
 
 ```js
-import { injectable, globalDi, runWithDi } from 'react-magnetic-di';
+import { injectable, runWithDi } from 'react-magnetic-di';
 import { myApiFetcher, fetchApi } from '.';
 
 it('should call the API', async () => {
@@ -189,11 +189,7 @@ it('should call the API', async () => {
     fetchApi,
     jest.mock().mockResolvedValue('mock')
   );
-  // either using globalDi use/clear manually
-  globalDi.use([fetchApiDi]);
-  const result = await myApiFetcher();
-  globalDi.clear();
-  // or using runWithDi which automatically handles use/clear
+
   const result = await runWithDi(() => myApiFetcher(), [fetchApiDi]);
 
   expect(fetchApiDi).toHaveBeenCalled();

--- a/examples/global/__tests__/index.test.ts
+++ b/examples/global/__tests__/index.test.ts
@@ -1,20 +1,15 @@
 /* eslint-env jest */
 
-import { injectable, globalDi, runWithDi } from 'react-magnetic-di';
+import { injectable, runWithDi } from 'react-magnetic-di';
 import { fetchApi, processApiData, apiHandler, transformer } from '..';
 
 const mockData = { data: [10, 20] };
 
 describe('transformer', () => {
-  afterEach(() => {
-    globalDi.clear();
-  });
-
   it('should transform data via processor', () => {
     const processApiDataDi = injectable(processApiData, (v) => [100, 200]);
-    globalDi.use([processApiDataDi]);
 
-    const result = transformer(mockData);
+    const result = runWithDi(() => transformer(mockData), [processApiDataDi]);
 
     expect(result).toEqual([100, 200]);
   });

--- a/examples/global/__tests__/index.test.ts
+++ b/examples/global/__tests__/index.test.ts
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+
+import { injectable, globalDi, runWithDi } from 'react-magnetic-di';
+import { fetchApi, processApiData, apiHandler, transformer } from '..';
+
+const mockData = { data: [10, 20] };
+
+describe('transformer', () => {
+  afterEach(() => {
+    globalDi.clear();
+  });
+
+  it('should transform data via processor', () => {
+    const processApiDataDi = injectable(processApiData, (v) => [100, 200]);
+    globalDi.use([processApiDataDi]);
+
+    const result = transformer(mockData);
+
+    expect(result).toEqual([100, 200]);
+  });
+});
+
+describe('apiHandler', () => {
+  it('should fetch API data', async () => {
+    const fetchApiDi = injectable(
+      fetchApi,
+      jest.fn().mockResolvedValue(mockData)
+    );
+
+    const result = await runWithDi(() => apiHandler(), [fetchApiDi]);
+
+    expect(fetchApiDi).toHaveBeenCalled();
+    expect(result).toEqual([100, 400]);
+  });
+});

--- a/examples/global/index.ts
+++ b/examples/global/index.ts
@@ -1,0 +1,17 @@
+import { di } from 'react-magnetic-di';
+
+type Data = { data: number[] };
+
+export const fetchApi = async (): Promise<Data> => ({ data: [1, 2] });
+export const processApiData = (data: Data['data']) => data.map((v) => v * v);
+
+export function transformer(response: Data) {
+  di(processApiData);
+  return processApiData(response.data);
+}
+
+export async function apiHandler() {
+  di(fetchApi, transformer);
+  const data = await fetchApi();
+  return transformer(data);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { di } from './react/consumer';
-export { globalDi, runWithDi } from './react/global';
+export { runWithDi } from './react/global';
 export { DiProvider, withDi } from './react/provider';
 export { mock, injectable } from './react/utils';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { di } from './react/consumer';
+export { globalDi, runWithDi } from './react/global';
 export { DiProvider, withDi } from './react/provider';
 export { mock, injectable } from './react/utils';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -5,19 +5,21 @@ import type { Node, AbstractComponent } from 'react';
 
 export type Dependency = Function;
 
-declare export class DiProvider extends React$Component<
-  {
-    children?: Node,
-    target?: AbstractComponent<any> | AbstractComponent<any>[],
-    use: Dependency[],
-  },
-  {
-    getDependencies: (
-      deps: Dependency[],
-      target: AbstractComponent<any> | AbstractComponent<any>[]
-    ) => Dependency[],
-  }
-> {}
+declare export class DiProvider
+  extends
+    React$Component<
+      {
+        children?: Node,
+        target?: AbstractComponent<any> | AbstractComponent<any>[],
+        use: Dependency[],
+      },
+      {
+        getDependencies: (
+          deps: Dependency[],
+          target: AbstractComponent<any> | AbstractComponent<any>[]
+        ) => Dependency[],
+      }
+    > {}
 
 declare export function withDi<T: AbstractComponent<any>>(
   component: T,
@@ -33,11 +35,17 @@ declare export function injectable<T: Dependency>(
   implementation: T
 ): T;
 
-// type ExtractReturn<Fn> = $Call<<T>((...Iterable<any>) => T) => T, Fn>;
-// declare export function injectable<T: (...args: any) => any>(
-//   from: T,
-//   implementation: Class<any> | ((...args: any) => ExtractReturn<T>)
-// ): T;
+type ExtractReturn<Fn> = $Call<<T>((...Iterable<any>) => T) => T, Fn>;
+
+declare export var globalDi: {
+  use(deps: Dependency[]): void,
+  clear(): void,
+};
+
+declare export function runWithDi<T: (...args: any) => any>(
+  thunk: T,
+  dependencies: Dependency[]
+): ExtractReturn<T>;
 
 function di(...dependencies: Dependency[]) {
   /** @deprecated use injectable instead */

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -37,11 +37,6 @@ declare export function injectable<T: Dependency>(
 
 type ExtractReturn<Fn> = $Call<<T>((...Iterable<any>) => T) => T, Fn>;
 
-declare export var globalDi: {
-  use(deps: Dependency[]): void,
-  clear(): void,
-};
-
 declare export function runWithDi<T: (...args: any) => any>(
   thunk: T,
   dependencies: Dependency[]

--- a/src/react/__tests__/common.js
+++ b/src/react/__tests__/common.js
@@ -32,3 +32,23 @@ export const TextDi = injectable(Text, () => <text-di />);
 export const WrapperDi = injectable(Wrapper, ({ children }) => (
   <wrapper-di>{children}</wrapper-di>
 ));
+
+export const fetchApi = async () => 'fetch';
+export const processApiData = (v) => v + ' process';
+
+export function transformer(data) {
+  const [_processApiData] = di([processApiData]);
+  return _processApiData(data);
+}
+
+export async function apiHandler() {
+  const [_fetchApi, _transformer] = di([fetchApi, transformer]);
+  const data = await _fetchApi();
+  return _transformer(data);
+}
+
+export const fetchApiDi = injectable(fetchApi, async () => 'fetch-di');
+export const processApiDataDi = injectable(
+  processApiData,
+  (v) => v + ' process-di'
+);

--- a/src/react/__tests__/global.test.js
+++ b/src/react/__tests__/global.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import { globalDi, runWithDi } from '../global';
+import {
+  apiHandler,
+  transformer,
+  processApiDataDi,
+  fetchApiDi,
+} from './common';
+
+describe('globalDi', () => {
+  afterEach(() => {
+    globalDi.clear();
+  });
+
+  it('should return real dependencies if not set', () => {
+    expect(transformer('data')).toEqual('data process');
+  });
+
+  it('should override all dependencies of same type', () => {
+    globalDi.use([processApiDataDi]);
+    expect(transformer('data')).toEqual('data process-di');
+  });
+
+  it('should clear injectables when told', () => {
+    globalDi.use([processApiDataDi]);
+    globalDi.clear();
+    expect(transformer('data')).toEqual('data process');
+  });
+});
+
+describe('runWithDi', () => {
+  it('should override sync functions', () => {
+    const deps = [processApiDataDi];
+    const result = runWithDi(() => transformer('data'), deps);
+    expect(result).toEqual('data process-di');
+  });
+
+  it('should override async functions', async () => {
+    const deps = [fetchApiDi, processApiDataDi];
+    const result = await runWithDi(() => apiHandler(), deps);
+    expect(result).toEqual('fetch-di process-di');
+  });
+});

--- a/src/react/__tests__/global.test.js
+++ b/src/react/__tests__/global.test.js
@@ -26,6 +26,11 @@ describe('globalDi', () => {
     globalDi.clear();
     expect(transformer('data')).toEqual('data process');
   });
+
+  it('should error when trying to use without having cleared first', () => {
+    globalDi.use([processApiDataDi]);
+    expect(() => globalDi.use([])).toThrow();
+  });
 });
 
 describe('runWithDi', () => {

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars, react/display-name */
 
 import React, { Component, type AbstractComponent } from 'react';
-import { injectable } from '../..';
+import { injectable, globalDi, runWithDi } from '../..';
 
 /**
  * Originals
@@ -53,3 +53,24 @@ injectable(ClassComponent, FunctionalMock);
 injectable(TypedComponent, FunctionalMock);
 injectable(TypedComponent, ClassMock);
 injectable(useHook, useMock);
+
+/**
+ * globalDi types tests
+ */
+const globalDep = () => '';
+globalDi.use([globalDep]);
+globalDi.clear();
+
+/**
+ * runWithDi types tests
+ */
+const runTestFn = () => '';
+const runTestAsyncFn = async () => '';
+
+const rsync = runWithDi(() => runTestFn(), [globalDep]);
+rsync.split('');
+
+async () => {
+  const rasync = await runWithDi(() => runTestAsyncFn(), []);
+  rasync.split('');
+};

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars, react/display-name */
 
 import React, { Component, type AbstractComponent } from 'react';
-import { injectable, globalDi, runWithDi } from '../..';
+import { injectable, runWithDi } from '../..';
 
 /**
  * Originals
@@ -55,15 +55,9 @@ injectable(TypedComponent, ClassMock);
 injectable(useHook, useMock);
 
 /**
- * globalDi types tests
- */
-const globalDep = () => '';
-globalDi.use([globalDep]);
-globalDi.clear();
-
-/**
  * runWithDi types tests
  */
+const globalDep = () => '';
 const runTestFn = () => '';
 const runTestAsyncFn = async () => '';
 

--- a/src/react/consumer.js
+++ b/src/react/consumer.js
@@ -1,17 +1,18 @@
 import { PACKAGE_NAME } from './constants';
 import { Context } from './context';
+import { globalDi } from './global';
 import { warnOnce, mock } from './utils';
 
 function di(deps, target) {
   // check if babel plugin has been added
   if (Array.isArray(deps)) {
     // Read context and grab all the dependencies override Providers in the tree
-    const { getDependencies = (v) => v } =
+    const { getDependencies } =
       // grab value from alt renderer (eg react-test-renderer)
       (Context._currentRenderer2 && Context._currentValue2) ||
       // grab value from default renderer
       Context._currentValue ||
-      {};
+      globalDi;
     return getDependencies(deps, target);
   } else {
     warnOnce(

--- a/src/react/context.js
+++ b/src/react/context.js
@@ -1,7 +1,6 @@
 import React from 'react';
+import { globalDi } from './global';
 
 export const Context = React.createContext({
-  getDependencies(deps) {
-    return deps;
-  },
+  getDependencies: globalDi.getDependencies,
 });

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -1,0 +1,40 @@
+import { KEY } from './constants';
+
+const replacementMap = new Map();
+
+export const globalDi = {
+  getDependencies(realDeps) {
+    return realDeps.map((dep) => replacementMap.get(dep) || dep);
+  },
+
+  use(deps) {
+    deps.forEach((d) => {
+      replacementMap.set(d[KEY], d);
+    });
+  },
+
+  clear() {
+    replacementMap.clear();
+  },
+};
+
+export function runWithDi(thunk, deps) {
+  globalDi.use(deps);
+  let result;
+  try {
+    result = thunk();
+    return result;
+  } finally {
+    // autocleanup dependences if either async or sync
+    if (
+      result &&
+      typeof result === 'object' &&
+      typeof result.then === 'function' &&
+      typeof result.finally === 'function'
+    ) {
+      result.finally(globalDi.clear);
+    } else {
+      globalDi.clear();
+    }
+  }
+}

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -10,9 +10,9 @@ export const globalDi = {
   use(deps) {
     if (replacementMap.size) {
       throw new Error(
-        `There are already replacements configured for ${PACKAGE_NAME}. ` +
-          `Implicit merging is not supported, so please concatenate them before calling globalDi.use(). ` +
-          `If this is not expected, ensure you call globalDi.clear() after each test`
+        `${PACKAGE_NAME} has replacements configured already. ` +
+          `Implicit merging is not supported, so please concatenate injectables. ` +
+          `If this is not expected, please file a bug report`
       );
     }
     deps.forEach((d) => {

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -1,4 +1,4 @@
-import { KEY } from './constants';
+import { KEY, PACKAGE_NAME } from './constants';
 
 const replacementMap = new Map();
 
@@ -8,6 +8,13 @@ export const globalDi = {
   },
 
   use(deps) {
+    if (replacementMap.size) {
+      throw new Error(
+        `There are already replacements configured for ${PACKAGE_NAME}. ` +
+          `Implicit merging is not supported, so please concatenate them before calling globalDi.use(). ` +
+          `If this is not expected, ensure you call globalDi.clear() after each test`
+      );
+    }
     deps.forEach((d) => {
       replacementMap.set(d[KEY], d);
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,11 +62,6 @@ declare module 'react-magnetic-di' {
     self: ComponentType<any> | null
   ): T[];
 
-  var globalDi: {
-    use(deps: Dependency[]): void;
-    clear(): void;
-  };
-
   function runWithDi<T extends () => any>(
     thunk: T,
     dependencies: Dependency[]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,6 +62,16 @@ declare module 'react-magnetic-di' {
     self: ComponentType<any> | null
   ): T[];
 
+  var globalDi: {
+    use(deps: Dependency[]): void;
+    clear(): void;
+  };
+
+  function runWithDi<T extends () => any>(
+    thunk: T,
+    dependencies: Dependency[]
+  ): ReturnType<T>;
+
   class di {
     /** @deprecated use injectable instead */
     static mock: typeof mock;

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { injectable, globalDi, runWithDi } from 'react-magnetic-di';
+import { injectable, runWithDi } from 'react-magnetic-di';
 
 /**
  * injectable types tests
@@ -141,21 +141,9 @@ injectable(FuncTwoProps, ClassNoProp);
 injectable(FuncTwoProps, FuncNoProp);
 
 /**
- * globalDi types tests
- */
-const globalDep = () => '';
-// @ts-expect-error - must provide deps
-globalDi.use();
-// @ts-expect-error - must provide array deps
-globalDi.use(globalDep);
-
-// Correct
-globalDi.use([globalDep]);
-globalDi.clear();
-
-/**
  * runWithDi types tests
  */
+const globalDep = () => '';
 const runTestFn = () => '';
 const runTestAsyncFn = async () => '';
 // @ts-expect-error - must be a thunk

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { injectable } from 'react-magnetic-di';
+import { injectable, globalDi, runWithDi } from 'react-magnetic-di';
 
 /**
  * injectable types tests
@@ -139,3 +139,37 @@ injectable(FuncTwoProps, FuncOneProp);
 // @ts-expect-error - this should be fine with React18 types
 injectable(FuncTwoProps, ClassNoProp);
 injectable(FuncTwoProps, FuncNoProp);
+
+/**
+ * globalDi types tests
+ */
+const globalDep = () => '';
+// @ts-expect-error - must provide deps
+globalDi.use();
+// @ts-expect-error - must provide array deps
+globalDi.use(globalDep);
+
+// Correct
+globalDi.use([globalDep]);
+globalDi.clear();
+
+/**
+ * runWithDi types tests
+ */
+const runTestFn = () => '';
+const runTestAsyncFn = async () => '';
+// @ts-expect-error - must be a thunk
+runWithDi(runTestFn(), []);
+// @ts-expect-error - must provide deps
+runWithDi(() => runTestFn());
+// @ts-expect-error - must provide array deps
+runWithDi(() => runTestFn(), globalDep);
+
+// Correct
+const rsync = runWithDi(() => runTestFn(), [globalDep]);
+rsync.split('');
+
+async () => {
+  const rasync = await runWithDi(() => runTestAsyncFn(), []);
+  rasync.split('');
+};


### PR DESCRIPTION
New API to use `di` outside of React.

```js
import { runWithDi } from 'react-magnetic-di'

const myDependencyDi = injectable(myDependency, () => 'mock')
runWithDi(() => myFunction(), [myDependencyDi]);
```
