### PR TITLE
Add stats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,30 @@ it('should call the API', async () => {
 });
 ```
 
+### Tracking unused/missing injectables
+
+By default `magnetic-di` does not complain if an injectable is not used or if a dependency has not being replaced. In large codebases however, that might led to issues with stale, unused injectables or with lack of knowledge in what could be replaced. To ease introspection, the library provides a `stats` API that returns both `unused` and `missing` injectables.
+
+- `stats.unused()` returns an array of entries `{ get(), error() }` for all injectables that have not been used since `stats.reset()` has been called
+- `stats.missing()` returns an array of entries `{ get(), error() }` for all dependencies that have not been replaced since `stats.reset()` has been called
+
+This is an example of stats guard implementation using the returned `error()` helper:
+
+```js
+import { stats } from 'react-magnetic-di';
+
+beforeEach(() => {
+  // it's important to reset the stats after each test
+  stats.reset();
+});
+afterEach(() => {
+  stats.unused().forEach((entry) => {
+    // throw an error pointing at the test with the unused injectable
+    throw entry.error();
+  });
+});
+```
+
 ### Configuration Options
 
 #### Enable dependency replacement on production (or custom env)

--- a/README.md
+++ b/README.md
@@ -197,12 +197,11 @@ it('should call the API', async () => {
 });
 ```
 
-### Tracking unused/missing injectables
+### Tracking unused injectables
 
-By default `magnetic-di` does not complain if an injectable is not used or if a dependency has not being replaced. In large codebases however, that might led to issues with stale, unused injectables or with lack of knowledge in what could be replaced. To ease introspection, the library provides a `stats` API that returns both `unused` and `missing` injectables.
+By default `magnetic-di` does not complain if an injectable is not used or if a dependency has not being replaced. In large codebases however, that might led to issues with stale, unused injectables or with lack of knowledge in what could be replaced. To ease introspection, the library provides a `stats` API that returns `unused` injectables.
 
 - `stats.unused()` returns an array of entries `{ get(), error() }` for all injectables that have not been used since `stats.reset()` has been called
-- `stats.missing()` returns an array of entries `{ get(), error() }` for all dependencies that have not been replaced since `stats.reset()` has been called
 
 This is an example of stats guard implementation using the returned `error()` helper:
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@ export { di } from './react/consumer';
 export { runWithDi } from './react/global';
 export { DiProvider, withDi } from './react/provider';
 export { mock, injectable } from './react/utils';
+export { stats } from './react/stats';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -42,6 +42,15 @@ declare export function runWithDi<T: (...args: any) => any>(
   dependencies: Dependency[]
 ): ExtractReturn<T>;
 
+declare export var stats: {
+  /** Returns unused injectables */
+  unused: () => Array<{ get: () => Dependency, error: () => Error }>,
+  /** Returns dependencies missing an injectable override */
+  missing: () => Array<{ get: () => Dependency, error: () => Error }>,
+  /** Resets stats */
+  reset: () => undefined,
+};
+
 function di(...dependencies: Dependency[]) {
   /** @deprecated use injectable instead */
   di.mock = mock;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -48,7 +48,7 @@ declare export var stats: {
   /** Returns dependencies missing an injectable override */
   missing: () => Array<{ get: () => Dependency, error: () => Error }>,
   /** Resets stats */
-  reset: () => undefined,
+  reset: () => void,
 };
 
 function di(...dependencies: Dependency[]) {

--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+/* eslint-env jest */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DiProvider, runWithDi, stats } from '../../index';
+import {
+  Label,
+  TextDi,
+  Wrapper,
+  WrapperDi,
+  apiHandler,
+  fetchApiDi,
+  processApiData,
+  processApiDataDi,
+  transformer,
+} from './common';
+
+describe('stats', () => {
+  afterEach(() => {
+    stats.reset();
+  });
+
+  describe('with DiProvider', () => {
+    it('should track used injectables', () => {
+      const deps = [TextDi, WrapperDi];
+      render(
+        <DiProvider use={deps}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.unused()).toHaveLength(0);
+    });
+
+    it('should track unused injectables', () => {
+      const deps = [TextDi, WrapperDi, fetchApiDi, processApiDataDi];
+      render(
+        <DiProvider use={deps}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.unused()).toHaveLength(2);
+      expect(stats.unused()[0].get()).toEqual(fetchApiDi);
+      expect(stats.unused()[1].get()).toEqual(processApiDataDi);
+    });
+
+    it('should track missing injectables', () => {
+      render(
+        <DiProvider use={[TextDi]}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.missing()).toHaveLength(1);
+      expect(stats.missing()[0].get()).toEqual(Wrapper);
+    });
+  });
+
+  describe('with runWithDi', () => {
+    it('should track used injectables', async () => {
+      const deps = [fetchApiDi, processApiDataDi];
+      await runWithDi(() => apiHandler(), deps);
+      expect(stats.unused()).toHaveLength(0);
+    });
+
+    it('should track unused injectables', async () => {
+      const deps = [fetchApiDi, processApiDataDi, TextDi, WrapperDi];
+      await runWithDi(() => apiHandler(), deps);
+      expect(stats.unused()).toHaveLength(2);
+      expect(stats.unused()[0].get()).toEqual(TextDi);
+      expect(stats.unused()[1].get()).toEqual(WrapperDi);
+    });
+
+    it('should track missing injectables', async () => {
+      const deps = [fetchApiDi];
+      await runWithDi(() => apiHandler(), deps);
+      expect(stats.missing()).toHaveLength(2);
+      expect(stats.missing()[0].get()).toEqual(transformer);
+      expect(stats.missing()[1].get()).toEqual(processApiData);
+    });
+  });
+});

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -78,7 +78,9 @@ stats.reset();
 
 // Correct
 unused.length > 1;
-unused.map((f) => f.call(null));
+unused[0].get().call;
+unused[0].error().stack;
 
 missing.length > 1;
-missing.map((f) => f.call(null));
+missing[0].get().call;
+missing[0].error().stack;

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars, react/display-name */
 
 import React, { Component, type AbstractComponent } from 'react';
-import { injectable, runWithDi } from '../..';
+import { injectable, runWithDi, stats } from '../..';
 
 /**
  * Originals
@@ -68,3 +68,17 @@ async () => {
   const rasync = await runWithDi(() => runTestAsyncFn(), []);
   rasync.split('');
 };
+
+/**
+ * stats types tests
+ */
+const unused = stats.unused();
+const missing = stats.missing();
+stats.reset();
+
+// Correct
+unused.length > 1;
+unused.map((f) => f.call(null));
+
+missing.length > 1;
+missing.map((f) => f.call(null));

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -1,10 +1,15 @@
 import { KEY, PACKAGE_NAME } from './constants';
+import { stats } from './stats';
 
 const replacementMap = new Map();
 
 export const globalDi = {
   getDependencies(realDeps) {
-    return realDeps.map((dep) => replacementMap.get(dep) || dep);
+    return realDeps.map((dep) => {
+      const replacedDep = replacementMap.get(dep);
+      stats.track(replacedDep, dep);
+      return replacedDep || dep;
+    });
   },
 
   use(deps) {
@@ -16,6 +21,7 @@ export const globalDi = {
       );
     }
     deps.forEach((d) => {
+      stats.set(d);
       replacementMap.set(d[KEY], d);
     });
   },

--- a/src/react/provider.js
+++ b/src/react/provider.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { KEY } from './constants';
 import { Context } from './context';
+import { stats } from './stats';
 import { getDisplayName } from './utils';
 
 export const DiProvider = ({ children, use, target }) => {
@@ -11,7 +12,10 @@ export const DiProvider = ({ children, use, target }) => {
   // memo provider value so gets computed only once
   const value = useMemo(() => {
     // create a map of dependency real -> replacement for fast lookup
-    const replacementMap = use.reduce((m, d) => m.set(d[KEY], d), new Map());
+    const replacementMap = use.reduce((m, d) => {
+      stats.set(d);
+      return m.set(d[KEY], d);
+    }, new Map());
     // support single or multiple targets
     const targets = target && (Array.isArray(target) ? target : [target]);
 
@@ -27,7 +31,10 @@ export const DiProvider = ({ children, use, target }) => {
             // so we check if here we need to inject a different one
             // or return the original / parent replacement
             const real = dep[KEY] || dep;
-            return replacementMap.get(real) || dep;
+            const replacedDep = replacementMap.get(real);
+            stats.track(replacedDep, dep);
+
+            return replacedDep || dep;
           });
         }
         return dependencies;

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -1,0 +1,57 @@
+import { KEY } from './constants';
+
+export const stats = {
+  state: {
+    unused: new Map(),
+    used: new Set(),
+    missing: new Map(),
+    provided: new Set(),
+  },
+
+  set(replacedDep) {
+    this.state.unused.set(
+      replacedDep,
+      new Error(
+        `Unused di injectable: ${replacedDep.displayName || replacedDep}`
+      )
+    );
+  },
+
+  track(replacedDep, dep) {
+    if (replacedDep) {
+      this.state.unused.delete(replacedDep);
+      this.state.used.add(replacedDep);
+      this.state.missing.delete(dep);
+      this.state.provided.add(dep);
+    } else if (!dep[KEY] && !this.state.provided.has(dep)) {
+      this.state.missing.set(
+        dep,
+        new Error(`Unreplaced di dependency: ${dep.displayName || dep}`)
+      );
+    }
+  },
+
+  reset() {
+    for (let key in this.state) {
+      this.state[key].clear();
+    }
+  },
+
+  unused() {
+    return Array.from(this.state.unused.entries()).map(
+      ([injectable, error]) => ({
+        get: () => injectable,
+        error: () => error,
+      })
+    );
+  },
+
+  missing() {
+    return Array.from(this.state.missing.entries()).map(
+      ([dependency, error]) => ({
+        get: () => dependency,
+        error: () => error,
+      })
+    );
+  },
+};

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -1,12 +1,14 @@
 import { KEY } from './constants';
 
+const createState = () => ({
+  unused: new Map(),
+  used: new Set(),
+  missing: new Map(),
+  provided: new Set(),
+});
+
 export const stats = {
-  state: {
-    unused: new Map(),
-    used: new Set(),
-    missing: new Map(),
-    provided: new Set(),
-  },
+  state: createState(),
 
   set(replacedDep) {
     this.state.unused.set(
@@ -32,9 +34,7 @@ export const stats = {
   },
 
   reset() {
-    for (let key in this.state) {
-      this.state[key].clear();
-    }
+    this.state = createState();
   },
 
   unused() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,5 @@
 declare module 'react-magnetic-di' {
-  import {
-    ComponentType,
-    ReactNode,
-    Component,
-    ComponentProps,
-    ComponentClass,
-  } from 'react';
+  import { ComponentType, ReactNode, Component, ComponentProps } from 'react';
 
   type Dependency = Function;
 
@@ -66,6 +60,15 @@ declare module 'react-magnetic-di' {
     thunk: T,
     dependencies: Dependency[]
   ): ReturnType<T>;
+
+  const stats: {
+    /** Returns unused injectables */
+    unused(): Array<{ get(): Dependency; error(): Error }>;
+    /** Returns dependencies missing an injectable override */
+    missing(): Array<{ get(): Dependency; error(): Error }>;
+    /** Resets stats */
+    reset(): void;
+  };
 
   class di {
     /** @deprecated use injectable instead */

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -8,7 +8,7 @@ import React, {
   ReactNode,
 } from 'react';
 
-import { injectable, runWithDi } from 'react-magnetic-di';
+import { injectable, runWithDi, stats } from 'react-magnetic-di';
 
 /**
  * injectable types tests
@@ -161,3 +161,17 @@ async () => {
   const rasync = await runWithDi(() => runTestAsyncFn(), []);
   rasync.split('');
 };
+
+/**
+ * stats types tests
+ */
+const unused = stats.unused();
+const missing = stats.missing();
+stats.reset();
+
+// Correct
+unused.length > 1;
+unused.map((f) => f.call(null));
+
+missing.length > 1;
+missing.map((f) => f.call(null));

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -171,7 +171,9 @@ stats.reset();
 
 // Correct
 unused.length > 1;
-unused.map((f) => f.call(null));
+unused[0].get().call;
+unused[0].error().stack;
 
 missing.length > 1;
-missing.map((f) => f.call(null));
+missing[0].get().call;
+missing[0].error().stack;


### PR DESCRIPTION
Adds a new `stats` API that allows reporting of unused/missing injectables.

```js
stats.unused().forEach((entry) => {
  // get the unused injectable
  console.log('Unused', entry.get());
  // use the helper to get more meaningful errors
  throw entry.error();
});

stats.missing().forEach((entry) => {
  // get the missing dependency
  console.log('Missing', entry.get());
  // use the helper to get more meaningful errors
  throw entry.error();
});

stats.reset();
```
Closes #69 . 
