### PR TITLE
Allow injectable to skip tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ function MyComponent() {
 
 ### Leveraging dependency replacement in tests and storybooks
 
-In the unit/integration tests or storybooks we can create a new injectable implementation and wrap the component with `DiProvider` to override such dependency:
+In the unit/integration tests or storybooks we can create a new `injectable` implementation and wrap the component with `DiProvider` to override such dependency:
 
 ```jsx
 import React from 'react';
@@ -185,16 +185,28 @@ import { injectable, runWithDi } from 'react-magnetic-di';
 import { myApiFetcher, fetchApi } from '.';
 
 it('should call the API', async () => {
-  const fetchApiDi = injectable(
-    fetchApi,
-    jest.mock().mockResolvedValue('mock')
-  );
+  const fetchApiDi = injectable(fetchApi, jest.fn().mockResolvedValue('mock'));
 
   const result = await runWithDi(() => myApiFetcher(), [fetchApiDi]);
 
   expect(fetchApiDi).toHaveBeenCalled();
   expect(result).toEqual('mock');
 });
+```
+
+### injectables configuration
+
+When creating injectables you can provide a configuration object to customise some of its behaviour.
+For instance, you can provide a custom `displayName` to make debugging easier:
+
+```js
+const fetchApiDi = injectable(fetchApi, jest.fn(), { displayName: 'fetchApi' });
+```
+
+Or you can skip reporting it in `stats.unused()` (handy if you provide default injectables across tests):
+
+```js
+const fetchApiDi = injectable(fetchApi, jest.fn(), { track: false });
 ```
 
 ### Tracking unused injectables

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -32,7 +32,8 @@ declare export function mock<T: Dependency>(original: T, mock: T): T;
 
 declare export function injectable<T: Dependency>(
   from: T,
-  implementation: T
+  implementation: T,
+  options?: {| displayName?: string, track?: boolean |}
 ): T;
 
 type ExtractReturn<Fn> = $Call<<T>((...Iterable<any>) => T) => T, Fn>;

--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { DiProvider, runWithDi, stats } from '../../index';
+import { DiProvider, injectable, runWithDi, stats } from '../../index';
 import {
   Label,
   TextDi,
@@ -42,6 +42,17 @@ describe('stats', () => {
       expect(stats.unused()).toHaveLength(2);
       expect(stats.unused()[0].get()).toEqual(fetchApiDi);
       expect(stats.unused()[1].get()).toEqual(processApiDataDi);
+    });
+
+    it('should not track injectables with tracking false', () => {
+      const ignore = injectable(() => {}, jest.fn(), { track: false });
+      const deps = [TextDi, WrapperDi, ignore];
+      render(
+        <DiProvider use={deps}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.unused()).toHaveLength(0);
     });
 
     it('should track missing injectables', () => {

--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -55,6 +55,17 @@ describe('stats', () => {
       expect(stats.unused()).toHaveLength(0);
     });
 
+    it('should not track overridden injectables', () => {
+      const WrapperOverrideDi = injectable(Wrapper, jest.fn());
+      const deps = [WrapperDi, WrapperOverrideDi];
+      render(
+        <DiProvider use={deps}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.unused()).toHaveLength(0);
+    });
+
     it('should track missing injectables', () => {
       render(
         <DiProvider use={[TextDi]}>

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -53,6 +53,8 @@ injectable(ClassComponent, FunctionalMock);
 injectable(TypedComponent, FunctionalMock);
 injectable(TypedComponent, ClassMock);
 injectable(useHook, useMock);
+injectable(useHook, useMock, { track: false });
+injectable(useHook, useMock, { displayName: 'useHookPrim1' });
 
 /**
  * runWithDi types tests

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -21,8 +21,8 @@ export const globalDi = {
       );
     }
     deps.forEach((d) => {
-      stats.set(d);
-      replacementMap.set(d[KEY], d);
+      if (d[KEY].track) stats.set(d);
+      replacementMap.set(d[KEY].from, d);
     });
   },
 

--- a/src/react/provider.js
+++ b/src/react/provider.js
@@ -13,8 +13,8 @@ export const DiProvider = ({ children, use, target }) => {
   const value = useMemo(() => {
     // create a map of dependency real -> replacement for fast lookup
     const replacementMap = use.reduce((m, d) => {
-      stats.set(d);
-      return m.set(d[KEY], d);
+      if (d[KEY].track) stats.set(d);
+      return m.set(d[KEY].from, d);
     }, new Map());
     // support single or multiple targets
     const targets = target && (Array.isArray(target) ? target : [target]);
@@ -30,7 +30,7 @@ export const DiProvider = ({ children, use, target }) => {
             // if another provider at the top has already swapped it
             // so we check if here we need to inject a different one
             // or return the original / parent replacement
-            const real = dep[KEY] || dep;
+            const real = dep[KEY]?.from || dep;
             const replacedDep = replacementMap.get(real);
             stats.track(replacedDep, dep);
 

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -19,7 +19,10 @@ export const stats = {
     this.state.unused.set(
       replacedDep,
       new Error(
-        `Unused di injectable: ${replacedDep.displayName || replacedDep}`
+        `Unused "di" injectable: ${
+          replacedDep.displayName || replacedDep
+        }. If this is on purpose, add "{track: false}" at injectable creation.`,
+        { cause: replacedDep[KEY].cause }
       )
     );
   },

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -11,6 +11,11 @@ export const stats = {
   state: createState(),
 
   set(replacedDep) {
+    // allow injectable override without flagging as unused
+    for (let injectable of this.state.unused.keys())
+      if (injectable[KEY].from === replacedDep[KEY].from)
+        this.state.unused.delete(injectable);
+
     this.state.unused.set(
       replacedDep,
       new Error(

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -19,9 +19,7 @@ export const stats = {
     this.state.unused.set(
       replacedDep,
       new Error(
-        `Unused "di" injectable: ${
-          replacedDep.displayName || replacedDep
-        }. If this is on purpose, add "{track: false}" at injectable creation.`,
+        `Unused "di" injectable: ${replacedDep.displayName || replacedDep}.`,
         { cause: replacedDep[KEY].cause }
       )
     );

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -25,7 +25,7 @@ export const stats = {
       this.state.used.add(replacedDep);
       this.state.missing.delete(dep);
       this.state.provided.add(dep);
-    } else if (!dep[KEY] && !this.state.provided.has(dep)) {
+    } else if (!dep[KEY]?.from && !this.state.provided.has(dep)) {
       this.state.missing.set(
         dep,
         new Error(`Unreplaced di dependency: ${dep.displayName || dep}`)

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -14,16 +14,22 @@ export function getDisplayName(Comp, wrapper = '') {
   return !name || !wrapper ? name : `${wrapper}(${name})`;
 }
 
-export function injectable(from, implementation) {
+export function injectable(
+  from,
+  implementation,
+  { displayName, track = true } = {}
+) {
   implementation.displayName =
-    getDisplayName(implementation) || getDisplayName(from, 'di');
-  if (implementation[KEY] && implementation[KEY] !== from) {
+    displayName || getDisplayName(implementation) || getDisplayName(from, 'di');
+  if (implementation[KEY]?.from && implementation[KEY]?.from !== from) {
     warnOnce(
       `You are trying to use replacement "${implementation.displayName}" on multiple injectables. ` +
         `That will override only the last dependency, as each replacement is uniquely linked.`
     );
   }
-  implementation[KEY] = from;
+  Object.defineProperty(implementation, KEY, {
+    value: { from, track },
+  });
   return implementation;
 }
 

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -29,7 +29,7 @@ export function injectable(
   }
   Object.defineProperty(implementation, KEY, {
     writable: true, // ideally this should be false, but sometimes devs reuse mocks
-    value: { from, track },
+    value: { from, track, cause: new Error() },
   });
   return implementation;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -29,7 +29,13 @@ export function injectable(
   }
   Object.defineProperty(implementation, KEY, {
     writable: true, // ideally this should be false, but sometimes devs reuse mocks
-    value: { from, track, cause: new Error() },
+    value: {
+      from,
+      track,
+      cause: new Error(
+        'Injectable created but not used. If this is on purpose, add "{track: false}"'
+      ),
+    },
   });
   return implementation;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -28,6 +28,7 @@ export function injectable(
     );
   }
   Object.defineProperty(implementation, KEY, {
+    writable: true, // ideally this should be false, but sometimes devs reuse mocks
     value: { from, track },
   });
   return implementation;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,9 +45,14 @@ declare module 'react-magnetic-di' {
 
   function injectable<T extends Dependency>(
     from: T,
-    implementation: ComponentOrFunction<T>
+    implementation: ComponentOrFunction<T>,
+    options?: { displayName?: string; track?: boolean }
   ): T;
-  function injectable<T extends Dependency>(from: T, implementation: T): T;
+  function injectable<T extends Dependency>(
+    from: T,
+    implementation: T,
+    options?: { displayName?: string; track?: boolean }
+  ): T;
 
   function di(...dependencies: Dependency[]): void;
   /** allow using di without Babel */

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -21,6 +21,8 @@ const useHookPrim1 = () => 'foo';
 injectable(useHookPrim1, () => true);
 // correct
 injectable(useHookPrim1, () => 'bar');
+injectable(useHookPrim1, () => 'bar', { track: false });
+injectable(useHookPrim1, () => 'bar', { displayName: 'useHookPrim1' });
 
 // Tuple hook simple test
 const useHookTuple1 = () => useState(true);


### PR DESCRIPTION
Add a configuration option to `injectable` to allow custom `displayName` and `track`