### PR TITLE
Remove stats.missing() API

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -46,8 +46,6 @@ declare export function runWithDi<T: (...args: any) => any>(
 declare export var stats: {
   /** Returns unused injectables */
   unused: () => Array<{ get: () => Dependency, error: () => Error }>,
-  /** Returns dependencies missing an injectable override */
-  missing: () => Array<{ get: () => Dependency, error: () => Error }>,
   /** Resets stats */
   reset: () => void,
 };

--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -11,9 +11,7 @@ import {
   WrapperDi,
   apiHandler,
   fetchApiDi,
-  processApiData,
   processApiDataDi,
-  transformer,
 } from './common';
 
 describe('stats', () => {
@@ -65,16 +63,6 @@ describe('stats', () => {
       );
       expect(stats.unused()).toHaveLength(0);
     });
-
-    it('should track missing injectables', () => {
-      render(
-        <DiProvider use={[TextDi]}>
-          <Label />
-        </DiProvider>
-      );
-      expect(stats.missing()).toHaveLength(1);
-      expect(stats.missing()[0].get()).toEqual(Wrapper);
-    });
   });
 
   describe('with runWithDi', () => {
@@ -90,14 +78,6 @@ describe('stats', () => {
       expect(stats.unused()).toHaveLength(2);
       expect(stats.unused()[0].get()).toEqual(TextDi);
       expect(stats.unused()[1].get()).toEqual(WrapperDi);
-    });
-
-    it('should track missing injectables', async () => {
-      const deps = [fetchApiDi];
-      await runWithDi(() => apiHandler(), deps);
-      expect(stats.missing()).toHaveLength(2);
-      expect(stats.missing()[0].get()).toEqual(transformer);
-      expect(stats.missing()[1].get()).toEqual(processApiData);
     });
   });
 });

--- a/src/react/__tests__/types.flow.js
+++ b/src/react/__tests__/types.flow.js
@@ -75,14 +75,9 @@ async () => {
  * stats types tests
  */
 const unused = stats.unused();
-const missing = stats.missing();
 stats.reset();
 
 // Correct
 unused.length > 1;
 unused[0].get().call;
 unused[0].error().stack;
-
-missing.length > 1;
-missing[0].get().call;
-missing[0].error().stack;

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -3,7 +3,6 @@ import { KEY } from './constants';
 const createState = () => ({
   unused: new Map(),
   used: new Set(),
-  missing: new Map(),
   provided: new Set(),
 });
 
@@ -29,13 +28,7 @@ export const stats = {
     if (replacedDep) {
       this.state.unused.delete(replacedDep);
       this.state.used.add(replacedDep);
-      this.state.missing.delete(dep);
       this.state.provided.add(dep);
-    } else if (!dep[KEY]?.from && !this.state.provided.has(dep)) {
-      this.state.missing.set(
-        dep,
-        new Error(`Unreplaced di dependency: ${dep.displayName || dep}`)
-      );
     }
   },
 
@@ -47,15 +40,6 @@ export const stats = {
     return Array.from(this.state.unused.entries()).map(
       ([injectable, error]) => ({
         get: () => injectable,
-        error: () => error,
-      })
-    );
-  },
-
-  missing() {
-    return Array.from(this.state.missing.entries()).map(
-      ([dependency, error]) => ({
-        get: () => dependency,
         error: () => error,
       })
     );

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,8 +73,6 @@ declare module 'react-magnetic-di' {
   const stats: {
     /** Returns unused injectables */
     unused(): Array<{ get(): Injectable; error(): Error }>;
-    /** Returns dependencies missing an injectable override */
-    missing(): Array<{ get(): Dependency; error(): Error }>;
     /** Resets stats */
     reset(): void;
   };

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -170,14 +170,9 @@ async () => {
  * stats types tests
  */
 const unused = stats.unused();
-const missing = stats.missing();
 stats.reset();
 
 // Correct
 unused.length > 1;
 unused[0].get().call;
 unused[0].error().stack;
-
-missing.length > 1;
-missing[0].get().call;
-missing[0].error().stack;


### PR DESCRIPTION
Didn't realise missing functionality runs also in dev mode. Removing for now until needs arise and we find a better way to enable tracking only in testing. Also it was not yet documented so should be fine to quickly patch