### PR TITLE
Add no-restricted-injectable eslint rule

### DIFF
--- a/src/eslint/rules/__tests__/no-restricted-injectable.test.js
+++ b/src/eslint/rules/__tests__/no-restricted-injectable.test.js
@@ -1,0 +1,73 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-restricted-injectable';
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true },
+  },
+});
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-restricted-injectable', rule, {
+  valid: [
+    // should pass if import is not restricted
+    `
+      import { useModal } from 'modal';
+      import { injectable } from 'react-magnetic-di';
+
+      injectable(useModal, () => {})
+    `,
+    {
+      // should pass if import name is not restricted
+      code: `
+        import { Suspense } from 'react';
+        import { injectable } from 'react-magnetic-di';
+
+        injectable(Suspense, () => null)
+      `,
+      options: [{ paths: [{ name: 'react', importNames: ['useState'] }] }],
+    },
+  ],
+
+  invalid: [
+    {
+      // should fail if whole module is not allowed
+      code: `
+        import { Suspense } from 'react';
+        import { injectable } from 'react-magnetic-di';
+
+        injectable(Suspense, () => null)
+      `,
+      options: [
+        {
+          paths: [{ name: 'react' }],
+        },
+      ],
+      errors: [{ type: 'CallExpression', messageId: 'restricted' }],
+    },
+    {
+      // should fail if specific import name is not allowed
+      code: `
+        import { useState } from 'react';
+        import { injectable } from 'react-magnetic-di';
+
+        injectable(useState, () => null)
+      `,
+      options: [
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['useState'],
+              message:
+                'For instance `const useLoading = () => useState(false)`',
+            },
+          ],
+        },
+      ],
+      errors: [{ type: 'CallExpression', message: /For instance/ }],
+    },
+  ],
+});

--- a/src/eslint/rules/no-restricted-injectable.js
+++ b/src/eslint/rules/no-restricted-injectable.js
@@ -1,0 +1,86 @@
+const { getInjectIdentifier, getImportIdentifiers } = require('../utils');
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Restrict certain dependencies from being injected',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    // fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          paths: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                importNames: { type: 'array' },
+                message: { type: 'string' },
+              },
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      restricted:
+        'This dependency should not be injected because too generic ' +
+        'or not needing a mock. If you want/need to mock it anyway, ' +
+        'please extract it into its own getter. {{message}}',
+    },
+  },
+  create: function (context) {
+    let injectIdentifier = null;
+
+    const userOptions = Object.assign({ paths: [] }, context.options[0]);
+    const restrictedVars = new Map();
+
+    return {
+      ImportDeclaration(node) {
+        if (!injectIdentifier) injectIdentifier = getInjectIdentifier(node);
+        for (let p of userOptions.paths) {
+          const ids = getImportIdentifiers(node, p.name, p.importNames) || [];
+          for (let id of ids) {
+            restrictedVars.set(id.name, { message: p.message || '' });
+          }
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.name !== injectIdentifier.name) return;
+
+        const [firstArg] = node.arguments || [];
+        const restrictedValue = restrictedVars.get(firstArg.name);
+        if (restrictedValue) {
+          context.report({
+            node,
+            messageId: 'restricted',
+            data: { message: restrictedValue.message },
+          });
+        }
+      },
+
+      // BlockStatement(node) {
+      //   if (!diIdentifier) return;
+
+      //   (node.body || []).forEach((statement, i) => {
+      //     if (!isDiStatement(statement, diIdentifier) || i === 0) return;
+
+      //     const prev = node.body[i - 1];
+      //     if (!isDiStatement(prev, diIdentifier)) {
+      //       context.report({
+      //         node: statement,
+      //         messageId: 'restricted',
+      //         data: { message },
+      //       });
+      //     }
+      //   });
+      // },
+    };
+  },
+};

--- a/src/eslint/rules/order.js
+++ b/src/eslint/rules/order.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Enforce injectable definition at the top of the block',
+      description: 'Enforce di() call expression at the top of the block',
       category: 'Possible Errors',
       recommended: true,
     },
@@ -12,7 +12,7 @@ module.exports = {
     schema: [],
     messages: {
       wrongOrder:
-        'Injectables should be defined at the top of their scope ' +
+        'di() calls should be defined at the top of their scope ' +
         'to avoid partial replacements and variables clashing',
     },
   },

--- a/src/eslint/utils.js
+++ b/src/eslint/utils.js
@@ -1,5 +1,6 @@
 const PACKAGE_NAME = 'react-magnetic-di';
 const PACKAGE_FUNCTION = 'di';
+const INJECT_FUNCTION = 'injectable';
 
 const isDiStatement = (stm, spec) =>
   stm.type === 'ExpressionStatement' &&
@@ -25,15 +26,21 @@ const isLocalVariable = (node, scope) => {
   return false;
 };
 
-const getDiIdentifier = (node) => {
+const getImportIdentifiers = (node, pkgName, impNames) => {
   const importSource = node.source.value;
-  const importSpecifier = node.specifiers.find(
-    (s) => s.imported && s.imported.name === PACKAGE_FUNCTION
+  const importSpecifiers = node.specifiers.filter(
+    (s) => s.imported && (!impNames || impNames.includes(s.imported.name))
   );
-  if (importSource.startsWith(PACKAGE_NAME) && importSpecifier) {
-    return importSpecifier.local;
+  if (importSource.startsWith(pkgName) && importSpecifiers.length) {
+    return importSpecifiers.map((s) => s.local);
   }
+  return null;
 };
+
+const getDiIdentifier = (n) =>
+  getImportIdentifiers(n, PACKAGE_NAME, [PACKAGE_FUNCTION])?.[0];
+const getInjectIdentifier = (n) =>
+  getImportIdentifiers(n, PACKAGE_NAME, [INJECT_FUNCTION])?.[0];
 
 const getDiStatements = (node, diIdentifier) =>
   (node.body || []).reduce(
@@ -67,6 +74,8 @@ module.exports = {
   isComponentName,
   isLocalVariable,
   getDiIdentifier,
+  getImportIdentifiers,
+  getInjectIdentifier,
   getDiStatements,
   getParentDiBlock,
   getParentDiStatements,


### PR DESCRIPTION
New ESLint rule to lint against problematic injectables (eg react imports)

```js
'no-restricted-injectable': [
  'error', 
  { 
    paths: [
      { name: 'react', importNames: ['useState'], message: 'Please extract it and create a dedicated hook.' }
    ],
  }
]
```