### PR TITLE
Ensure break identifier reference

### DIFF
--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -678,7 +678,9 @@ describe('babel plugin', () => {
       import { useModal } from 'modal';
 
       function useMyModal() {
-        return useModal();
+        return (() => {
+          return useModal();
+        })
       }
     `;
     expect(
@@ -692,7 +694,10 @@ describe('babel plugin', () => {
       var _modal = require("modal");
       function useMyModal() {
         const [_useModal] = (0, _reactMagneticDi.di)([_modal.useModal], useMyModal);
-        return _useModal();
+        return () => {
+          const [_useModal2] = (0, _reactMagneticDi.di)([_useModal], null);
+          return _useModal2();
+        };
       }"
     `);
   });

--- a/src/babel/processor-di.js
+++ b/src/babel/processor-di.js
@@ -35,7 +35,7 @@ function processReference(t, path, locationValue, state) {
   const declaration = t.variableDeclaration('const', [
     t.variableDeclarator(
       t.arrayPattern(elements),
-      t.callExpression(state.diIdentifier, [
+      t.callExpression(t.identifier(state.diIdentifier.name), [
         t.arrayExpression(args),
         self ? t.identifier(self.name) : t.nullLiteral(),
       ])


### PR DESCRIPTION
Using the same identifier reference breaks CommonJS transformation, we need new identifier instances on every added `di` expression