### PR TITLE
Add provider global behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When you have the same dependency replaced multiple times, there are two behavio
 
 ### Other replacement patterns
 
-#### Allowing globals replacement
+#### Allowing globals (variables) replacement
 
 Currently the library does not enable automatic replacement of globals. To do that, you need to manually "tag" a global for replacement with `di(myGlobal)` in the function scope. For instance:
 
@@ -259,17 +259,31 @@ const fetchApiDi = injectable(fetchApi, jest.fn(), { target: fetchProjects });
 const fetchApiDi = injectable(fetchApi, jest.fn(), { track: false });
 ```
 
+• `global`: allows a replacement to be available evewhere, at any point, until `DiProvider` unmounts (alternatively use `global` prop on `DiProvider` to make all `use` replacements act globally):
+
+```js
+const fetchApiDi = injectable(fetchApi, jest.fn(), { global: true });
+```
+
+#### DiProvider props
+
+• `use`: required prop, it is an array of replacements
+• `target`: allows a replacement to only apply to specific components(s)
+• `global`: boolean, allows replacements to be available outside the render phase
+
+````
+
 ## ESLint plugin and rules
 
 In order to enforce better practices, this package exports some ESLint rules:
 
-| rule                       | description                                                                                                          |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `order`                    | enforces `di(...)` to be the top of the block, to reduce chances of partial replacements                             |
-| `no-duplicate`             | prohibits marking the same dependency as injectable more than once in the same scope                                 |
-| `no-extraneous`            | enforces dependencies to be consumed in the scope, to prevent unused variables                                       |
+| rule                       | description                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `order`                    | enforces `di(...)` to be the top of the block, to reduce chances of partial replacements                            |
+| `no-duplicate`             | prohibits marking the same dependency as injectable more than once in the same scope                                |
+| `no-extraneous`            | enforces dependencies to be consumed in the scope, to prevent unused variables                                      |
 | `no-restricted-injectable` | prohibits certain values from being injected: `paths: [{ name: string, importNames?: string[], message?: string }]` |
-| `sort-dependencies`        | require injectable dependencies to be sorted                                                                         |
+| `sort-dependencies`        | require injectable dependencies to be sorted                                                                        |
 
 The rules are exported from `react-magnetic-di/eslint-plugin`. Unfortunately ESLint does not allow plugins that are not npm packages, so rules needs to be imported via other means for now.
 
@@ -291,7 +305,10 @@ import { debug } from 'react-magnetic-di';
 // ...
 console.log(debug(myApiFetcher));
 // It will print ['fetchApi']
-```
+````
+
+One possible reason for it to happen is that the context has been lost. Typical occurrences are async or deeply nested functions (especially in React).
+The solution is setting the prop `global` on `DiProvider` (or the same injectable config) to better handle those scenarios (but refrain from abusing it).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ const fetchApiDi = injectable(fetchApi, jest.fn(), { target: fetchProjects });
 const fetchApiDi = injectable(fetchApi, jest.fn(), { track: false });
 ```
 
-• `global`: allows a replacement to be available evewhere, at any point, until `DiProvider` unmounts (alternatively use `global` prop on `DiProvider` to make all `use` replacements act globally):
+• `global`: allows a replacement to be available everywhere, at any point, until `DiProvider` unmounts (alternatively use `global` prop on `DiProvider` to make all `use` replacements act globally):
 
 ```js
 const fetchApiDi = injectable(fetchApi, jest.fn(), { global: true });

--- a/src/react/__tests__/common.js
+++ b/src/react/__tests__/common.js
@@ -18,10 +18,16 @@ export class Label extends Component {
 }
 
 export class Input extends Component {
+  state = { value: '' };
+  componentDidMount() {
+    const [_apiHandler] = di([apiHandler], Input);
+    _apiHandler().then((value) => this.setState({ value }));
+  }
+
   render() {
     const [_Text] = di([Text], Input);
     return (
-      <input-og>
+      <input-og value={this.state.value}>
         <_Text />
       </input-og>
     );
@@ -47,7 +53,9 @@ export async function apiHandler() {
   return _transformer(data);
 }
 
-export const fetchApiDi = injectable(fetchApi, async () => 'fetch-di');
+export const fetchApiDi = injectable(fetchApi, async () => 'fetch-di', {
+  global: true,
+});
 export const processApiDataDi = injectable(
   processApiData,
   (v) => v + ' process-di'

--- a/src/react/__tests__/global.test.js
+++ b/src/react/__tests__/global.test.js
@@ -6,6 +6,7 @@ import {
   apiHandler,
   fetchApi,
   fetchApiDi,
+  processApiData,
   processApiDataDi,
   transformer,
 } from './common';
@@ -38,6 +39,12 @@ describe('globalDi', () => {
     expect(transformer('data')).toEqual('data process-og');
   });
 
+  it('should remove injectables when told', () => {
+    globalDi.use([processApiDataDi, fetchApiDi]);
+    globalDi._remove([processApiDataDi]);
+    expect(transformer('data')).toEqual('data process-og');
+  });
+
   it('should error when trying to use without having cleared first', () => {
     globalDi.use([processApiDataDi]);
     expect(() => globalDi.use([])).toThrow();
@@ -47,6 +54,22 @@ describe('globalDi', () => {
     expect(() => {
       globalDi.use([jest.fn()]);
     }).toThrowError();
+  });
+
+  describe('_fromProvider', () => {
+    it('should add all injectables with global prop', () => {
+      globalDi._fromProvider([injectable(processApiData, () => 'process-di')], {
+        global: true,
+      });
+      expect(transformer('data')).toEqual('process-di');
+    });
+
+    it('should add injectables with global config', () => {
+      globalDi._fromProvider([
+        injectable(processApiData, () => 'process-di', { global: true }),
+      ]);
+      expect(transformer('data')).toEqual('process-di');
+    });
   });
 
   describe('with various replacement types', () => {

--- a/src/react/__tests__/integration-rtl.test.js
+++ b/src/react/__tests__/integration-rtl.test.js
@@ -2,18 +2,31 @@
 /* eslint-env jest */
 
 import React, { Fragment } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { DiProvider, withDi, injectable } from '../../index';
-import { Label, Input, Text, TextDi, Wrapper, WrapperDi } from './common';
+import {
+  Label,
+  Input,
+  Text,
+  TextDi,
+  Wrapper,
+  WrapperDi,
+  processApiDataDi,
+  fetchApiDi,
+} from './common';
+
+const tick = () => act(() => Promise.resolve());
 
 describe('Integration: testing-library', () => {
-  it('should return real dependencies if provider-less', () => {
+  it('should return real dependencies if provider-less', async () => {
     const { container } = render(
       <Fragment>
         <Label />
         <Input />
       </Fragment>
     );
+
+    await tick();
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -22,20 +35,24 @@ describe('Integration: testing-library', () => {
             <text-og />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-og />
         </input-og>
       </div>
     `);
   });
 
-  it('should override all dependencies of same type', () => {
+  it('should override all dependencies of same type', async () => {
     const { container } = render(
       <DiProvider use={[TextDi]}>
         <Label />
         <Input />
       </DiProvider>
     );
+
+    await tick();
 
     expect(container).toMatchInlineSnapshot(`
       <div>
@@ -44,14 +61,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di />
         </input-og>
       </div>
     `);
   });
 
-  it('should allow override composition', () => {
+  it('should allow override composition', async () => {
     const { container } = render(
       <DiProvider use={[WrapperDi]}>
         <DiProvider use={[TextDi]}>
@@ -61,6 +80,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -68,14 +89,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-di>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di />
         </input-og>
       </div>
     `);
   });
 
-  it('should only override dependencies of specified target', () => {
+  it('should only override dependencies of specified target', async () => {
     const { container } = render(
       <DiProvider target={[Input]} use={[WrapperDi]}>
         <DiProvider target={Label} use={[TextDi]}>
@@ -85,6 +108,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -92,14 +117,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-og />
         </input-og>
       </div>
     `);
   });
 
-  it('should only override dependencies of specified injectable target', () => {
+  it('should only override dependencies of specified injectable target', async () => {
     const deps = [
       injectable(Text, () => <text-di />, { target: Label }),
       injectable(Wrapper, (p) => <wrapper-di>{p.children}</wrapper-di>, {
@@ -114,6 +141,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -121,14 +150,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-og />
         </input-og>
       </div>
     `);
   });
 
-  it('should only override dependencies of specified injectable targets array', () => {
+  it('should only override dependencies of specified injectable targets array', async () => {
     const deps = [
       injectable(Text, () => <text-di />, { target: [Label, Input] }),
     ];
@@ -140,6 +171,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -147,14 +180,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di />
         </input-og>
       </div>
     `);
   });
 
-  it('should allow override of same dependency with different targets', () => {
+  it('should allow override of same dependency with different targets', async () => {
     const deps = [
       injectable(Text, () => <text-di-label />, { target: Label }),
       injectable(Text, () => <text-di-input />, { target: Input }),
@@ -167,6 +202,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -174,14 +211,16 @@ describe('Integration: testing-library', () => {
             <text-di-label />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di-input />
         </input-og>
       </div>
     `);
   });
 
-  it('should override with target version even when first if dependency has multiple injectables', () => {
+  it('should override with target version even when first if dependency has multiple injectables', async () => {
     const deps = [
       injectable(Text, () => <text-di-target />, { target: Input }),
       injectable(Text, () => <text-di />),
@@ -194,6 +233,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -201,14 +242,16 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di-target />
         </input-og>
       </div>
     `);
   });
 
-  it('should override with target version even when last if dependency has multiple injectables', () => {
+  it('should override with target version even when last if dependency has multiple injectables', async () => {
     const deps = [
       injectable(Text, () => <text-di />),
       injectable(Text, () => <text-di-target />, { target: Input }),
@@ -221,6 +264,8 @@ describe('Integration: testing-library', () => {
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -228,24 +273,28 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di-target />
         </input-og>
       </div>
     `);
   });
 
-  it('should get closest dependency if multiple providers using same type', () => {
+  it('should get closest dependency if multiple providers using same type', async () => {
     const TextDi2 = injectable(Text, () => <text-di2 />);
     TextDi2.displayName = 'di(Text2)';
     const WrappedInput = withDi(Input, [TextDi2]);
     const { container } = render(
-      <DiProvider use={[TextDi]}>
+      <DiProvider use={[TextDi, processApiDataDi /* ignored */]}>
         <Label />
         <WrappedInput />
       </DiProvider>
     );
 
+    await tick();
+
     expect(container).toMatchInlineSnapshot(`
       <div>
         <label-og>
@@ -253,8 +302,30 @@ describe('Integration: testing-library', () => {
             <text-di />
           </wrapper-og>
         </label-og>
-        <input-og>
+        <input-og
+          value="fetch-og process-og"
+        >
           <text-di2 />
+        </input-og>
+      </div>
+    `);
+  });
+
+  it('should get global injectable if global prop set', async () => {
+    const { container } = render(
+      <DiProvider use={[processApiDataDi, fetchApiDi]} global>
+        <Input />
+      </DiProvider>
+    );
+
+    await tick();
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <input-og
+          value="fetch-di process-di"
+        >
+          <text-og />
         </input-og>
       </div>
     `);

--- a/src/react/__tests__/integration-rtr.test.js
+++ b/src/react/__tests__/integration-rtr.test.js
@@ -1,17 +1,21 @@
 /* eslint-env jest */
 import React, { Fragment } from 'react';
-import { create } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
 import { DiProvider, withDi, injectable } from '../../index';
 import { Label, Input, Text, TextDi, WrapperDi } from './common';
 
+const tick = () => act(() => Promise.resolve());
+
 describe('Integration: react-test-renderer', () => {
-  it('should return real dependencies if provider-less', () => {
+  it('should return real dependencies if provider-less', async () => {
     const tree = create(
       <Fragment>
         <Label />
         <Input />
       </Fragment>
     ).toJSON();
+
+    await tick();
 
     expect(tree).toMatchInlineSnapshot(`
       [
@@ -20,20 +24,24 @@ describe('Integration: react-test-renderer', () => {
             <text-og />
           </wrapper-og>
         </label-og>,
-        <input-og>
+        <input-og
+          value=""
+        >
           <text-og />
         </input-og>,
       ]
     `);
   });
 
-  it('should override all dependencies of same type', () => {
+  it('should override all dependencies of same type', async () => {
     const tree = create(
       <DiProvider use={[TextDi]}>
         <Label />
         <Input />
       </DiProvider>
     ).toJSON();
+
+    await tick();
 
     expect(tree).toMatchInlineSnapshot(`
       [
@@ -42,14 +50,16 @@ describe('Integration: react-test-renderer', () => {
             <text-di />
           </wrapper-og>
         </label-og>,
-        <input-og>
+        <input-og
+          value=""
+        >
           <text-di />
         </input-og>,
       ]
     `);
   });
 
-  it('should allow override composition', () => {
+  it('should allow override composition', async () => {
     const tree = create(
       <DiProvider use={[WrapperDi]}>
         <DiProvider use={[TextDi]}>
@@ -59,6 +69,8 @@ describe('Integration: react-test-renderer', () => {
       </DiProvider>
     ).toJSON();
 
+    await tick();
+
     expect(tree).toMatchInlineSnapshot(`
       [
         <label-og>
@@ -66,14 +78,16 @@ describe('Integration: react-test-renderer', () => {
             <text-di />
           </wrapper-di>
         </label-og>,
-        <input-og>
+        <input-og
+          value=""
+        >
           <text-di />
         </input-og>,
       ]
     `);
   });
 
-  it('should only override dependencies of specified target', () => {
+  it('should only override dependencies of specified target', async () => {
     const tree = create(
       <DiProvider target={[Input]} use={[WrapperDi]}>
         <DiProvider target={Label} use={[TextDi]}>
@@ -83,6 +97,8 @@ describe('Integration: react-test-renderer', () => {
       </DiProvider>
     ).toJSON();
 
+    await tick();
+
     expect(tree).toMatchInlineSnapshot(`
       [
         <label-og>
@@ -90,14 +106,16 @@ describe('Integration: react-test-renderer', () => {
             <text-di />
           </wrapper-og>
         </label-og>,
-        <input-og>
+        <input-og
+          value=""
+        >
           <text-og />
         </input-og>,
       ]
     `);
   });
 
-  it('should get closest dependency if multiple providers using same type', () => {
+  it('should get closest dependency if multiple providers using same type', async () => {
     const TextDi2 = injectable(Text, () => <text-di2 />);
     TextDi2.displayName = 'di(Text2)';
     const WrappedInput = withDi(Input, [TextDi2]);
@@ -108,6 +126,8 @@ describe('Integration: react-test-renderer', () => {
       </DiProvider>
     ).toJSON();
 
+    await tick();
+
     expect(tree).toMatchInlineSnapshot(`
       [
         <label-og>
@@ -115,7 +135,9 @@ describe('Integration: react-test-renderer', () => {
             <text-di />
           </wrapper-og>
         </label-og>,
-        <input-og>
+        <input-og
+          value=""
+        >
           <text-di2 />
         </input-og>,
       ]

--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -31,15 +31,15 @@ describe('stats', () => {
     });
 
     it('should track unused injectables', () => {
-      const deps = [TextDi, WrapperDi, fetchApiDi, processApiDataDi];
+      const deps = [TextDi, WrapperDi, processApiDataDi, fetchApiDi];
       render(
         <DiProvider use={deps}>
           <Label />
         </DiProvider>
       );
       expect(stats.unused()).toHaveLength(2);
-      expect(stats.unused()[0].get()).toEqual(fetchApiDi);
-      expect(stats.unused()[1].get()).toEqual(processApiDataDi);
+      expect(stats.unused()[0].get()).toEqual(processApiDataDi);
+      expect(stats.unused()[1].get()).toEqual(fetchApiDi);
     });
 
     it('should not track injectables with tracking false', () => {

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -1,5 +1,9 @@
-import { PACKAGE_NAME } from './constants';
-import { addInjectableToMap, findInjectable } from './utils';
+import { PACKAGE_NAME, diRegistry } from './constants';
+import {
+  addInjectableToMap,
+  removeInjectableFromMap,
+  findInjectable,
+} from './utils';
 
 const replacementMap = new Map();
 
@@ -24,6 +28,17 @@ export const globalDi = {
 
   clear() {
     replacementMap.clear();
+  },
+
+  _fromProvider(injs, props = {}) {
+    injs.forEach((inj) => {
+      if (props.global || diRegistry.get(inj).global)
+        addInjectableToMap(replacementMap, inj);
+    });
+  },
+
+  _remove(injs) {
+    injs.forEach((inj) => removeInjectableFromMap(replacementMap, inj));
   },
 };
 

--- a/src/react/injectable.js
+++ b/src/react/injectable.js
@@ -4,7 +4,7 @@ import { getDisplayName, warnOnce } from './utils';
 export function injectable(
   from,
   implementation,
-  { displayName, target, track = true } = {}
+  { displayName, target, track = true, global = false } = {}
 ) {
   let impl = implementation;
   if (typeof impl === 'function') {
@@ -31,9 +31,12 @@ export function injectable(
     from,
     targets: target && (Array.isArray(target) ? target : [target]),
     track,
-    cause: new Error(
-      'Injectable created but not used. If this is on purpose, add "{track: false}"'
-    ),
+    global,
+    cause: track
+      ? new Error(
+          'Injectable created but not used. If this is on purpose, add "{track: false}"'
+        )
+      : null,
   });
   return impl;
 }

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -19,6 +19,8 @@ export const stats = {
         { cause: injObj.cause }
       )
     );
+    // reset to avoid potential memory leaks via stack traces
+    injObj.cause = null;
   },
 
   track(inj) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -19,25 +19,22 @@ export function addInjectableToMap(replacementMap, inj) {
   }
 
   if (injObj.track) stats.set(injObj);
-  if (
-    replacementMap.has(injObj.from) &&
-    !replacementMap.get(injObj.from).includes(injObj)
-  ) {
-    replacementMap.get(injObj.from).unshift(injObj);
+
+  if (replacementMap.has(injObj.from)) {
+    replacementMap.get(injObj.from).add(injObj);
   } else {
-    replacementMap.set(injObj.from, [injObj]);
+    replacementMap.set(injObj.from, new Set([injObj]));
   }
   return replacementMap;
 }
 
 export function removeInjectableFromMap(replacementMap, inj) {
   const injObj = diRegistry.get(inj);
-  const injectables = replacementMap.get(injObj.from) || [];
-  if (injectables.length === 1) {
+  const injectables = replacementMap.get(injObj.from) || new Set();
+  if (injectables.size === 1) {
     replacementMap.delete(injObj.from);
   } else {
-    const idx = injectables.indexOf(injObj);
-    injectables.splice(idx, 1);
+    injectables.delete(injObj);
   }
 }
 
@@ -53,13 +50,15 @@ export function debug(fn) {
 }
 
 export function findInjectable(replacementMap, dep, targetChild) {
-  const injectables = replacementMap.get(dep) || [];
-  const candidates = [];
-  // loop all injectables for the dep, ranking targeted ones higher
+  const injectables = replacementMap.get(dep) || new Set();
+  // loop all injectables for the dep, with targeted ones preferred
+  let anyCandidate = null;
+  let targetCandidate = null;
   for (const inj of injectables) {
-    if (!inj.targets) candidates.push(inj);
-    if (inj.targets?.includes(targetChild)) candidates.unshift(inj);
+    if (!inj.targets) anyCandidate = inj;
+    if (inj.targets?.includes(targetChild)) targetCandidate = inj;
   }
-  stats.track(candidates[0]);
-  return candidates[0] || null;
+  const candidate = targetCandidate || anyCandidate;
+  stats.track(candidate);
+  return candidate;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -19,12 +19,26 @@ export function addInjectableToMap(replacementMap, inj) {
   }
 
   if (injObj.track) stats.set(injObj);
-  if (replacementMap.has(injObj.from)) {
+  if (
+    replacementMap.has(injObj.from) &&
+    !replacementMap.get(injObj.from).includes(injObj)
+  ) {
     replacementMap.get(injObj.from).unshift(injObj);
   } else {
     replacementMap.set(injObj.from, [injObj]);
   }
   return replacementMap;
+}
+
+export function removeInjectableFromMap(replacementMap, inj) {
+  const injObj = diRegistry.get(inj);
+  const injectables = replacementMap.get(injObj.from) || [];
+  if (injectables.length === 1) {
+    replacementMap.delete(injObj.from);
+  } else {
+    const idx = injectables.indexOf(injObj);
+    injectables.splice(idx, 1);
+  }
 }
 
 export function getDisplayName(Comp, wrapper = '') {


### PR DESCRIPTION
This PR adds a new prop to `DiProvider` and a config to `injectable`: `global: bool`.
It enables declared replacements to be available in the global scope (and so outside the render context) until the component gets unmounted.