### PR TITLE
fix: handle temporal deadzone for local variables shadowing parent function

### DIFF
--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -842,14 +842,14 @@ describe('babel plugin', () => {
       "import { di as _di } from "react-magnetic-di";
       import Modal, { config } from 'modal';
       function createClass() {
-        var _MyModal;
+        var _class;
         const [_Modal, _config] = _di([Modal, config], createClass);
-        return _MyModal = class MyModal extends _Modal {
+        return _class = class MyModal extends _Modal {
           getConfig() {
             const [_config2] = _di([_config], MyModal);
             return _config2;
           }
-        }, _MyModal.displayName = 'MyModal', _MyModal;
+        }, _class.displayName = 'MyModal', _class;
         return MyModal;
       }"
     `);

--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -103,6 +103,25 @@ describe('babel plugin', () => {
     `);
   });
 
+  it('should work with shadowed variables', () => {
+    const input = `            
+      import LinkifyIt from 'linkify-it';
+      const linkify = (state) => {
+        // cannot refer to the function location ^ as there is a local variable shadowing it
+        const linkify = new LinkifyIt();
+      }
+    `;
+    expect(babel(input)).toMatchInlineSnapshot(`
+      "import { di as _di } from "react-magnetic-di";
+      import LinkifyIt from 'linkify-it';
+      const linkify = state => {
+        const [_LinkifyIt] = _di([LinkifyIt], null);
+        // cannot refer to the function location ^ as there is a local variable shadowing it
+        const linkify = new _LinkifyIt();
+      };"
+    `);
+  });
+
   it('should work and maintain location if manually declared', () => {
     const input = `
       import React from 'react';

--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -103,23 +103,93 @@ describe('babel plugin', () => {
     `);
   });
 
-  it('should work with shadowed variables', () => {
-    const input = `            
+  describe('shadowed variables', () => {
+    it('simple case: should remove', () => {
+      const input = `            
       import LinkifyIt from 'linkify-it';
       const linkify = (state) => {
         // cannot refer to the function location ^ as there is a local variable shadowing it
         const linkify = new LinkifyIt();
       }
     `;
-    expect(babel(input)).toMatchInlineSnapshot(`
-      "import { di as _di } from "react-magnetic-di";
+      expect(babel(input)).toMatchInlineSnapshot(`
+              "import { di as _di } from "react-magnetic-di";
+              import LinkifyIt from 'linkify-it';
+              const linkify = state => {
+                const [_LinkifyIt] = _di([LinkifyIt], null);
+                // cannot refer to the function location ^ as there is a local variable shadowing it
+                const linkify = new _LinkifyIt();
+              };"
+          `);
+    });
+
+    it('nested function case: should keep', () => {
+      const input = `            
       import LinkifyIt from 'linkify-it';
-      const linkify = state => {
-        const [_LinkifyIt] = _di([LinkifyIt], null);
-        // cannot refer to the function location ^ as there is a local variable shadowing it
-        const linkify = new _LinkifyIt();
-      };"
-    `);
+      const linkify = (state) => {
+        useEffect(() => {        
+          const linkify = new LinkifyIt();
+        });
+      }
+    `;
+      expect(babel(input)).toMatchInlineSnapshot(`
+        "import { di as _di } from "react-magnetic-di";
+        import LinkifyIt from 'linkify-it';
+        const linkify = state => {
+          const [_LinkifyIt] = _di([LinkifyIt], linkify);
+          useEffect(() => {
+            const [_LinkifyIt2] = _di([_LinkifyIt], null);
+            const linkify = new _LinkifyIt2();
+          });
+        };"
+      `);
+    });
+
+    it('block case: should keep', () => {
+      const input = `            
+      import LinkifyIt from 'linkify-it';
+      const linkify = (state) => {
+        if (ff('xx')) {   
+           const linkify = new LinkifyIt();
+        }
+      }
+    `;
+      expect(babel(input)).toMatchInlineSnapshot(`
+        "import { di as _di } from "react-magnetic-di";
+        import LinkifyIt from 'linkify-it';
+        const linkify = state => {
+          const [_LinkifyIt] = _di([LinkifyIt], linkify);
+          if (ff('xx')) {
+            const linkify = new _LinkifyIt();
+          }
+        };"
+      `);
+    });
+
+    it('mixed case: should keep', () => {
+      const input = `            
+      import LinkifyIt from 'linkify-it';
+      import LinkifyThat from 'linkify-it';
+      const linkify = (state) => {
+        const linkify = new LinkifyIt();
+        if (ff('xx')) {   
+           const linkify = new LinkifyThat();        
+        }
+      }
+    `;
+      expect(babel(input)).toMatchInlineSnapshot(`
+        "import { di as _di } from "react-magnetic-di";
+        import LinkifyIt from 'linkify-it';
+        import LinkifyThat from 'linkify-it';
+        const linkify = state => {
+          const [_LinkifyIt, _LinkifyThat] = _di([LinkifyIt, LinkifyThat], null);
+          const linkify = new _LinkifyIt();
+          if (ff('xx')) {
+            const linkify = new _LinkifyThat();
+          }
+        };"
+      `);
+    });
   });
 
   it('should work and maintain location if manually declared', () => {

--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -842,14 +842,14 @@ describe('babel plugin', () => {
       "import { di as _di } from "react-magnetic-di";
       import Modal, { config } from 'modal';
       function createClass() {
-        var _class;
+        var _MyModal;
         const [_Modal, _config] = _di([Modal, config], createClass);
-        return _class = class MyModal extends _Modal {
+        return _MyModal = class MyModal extends _Modal {
           getConfig() {
             const [_config2] = _di([_config], MyModal);
             return _config2;
           }
-        }, _class.displayName = 'MyModal', _class;
+        }, _MyModal.displayName = 'MyModal', _MyModal;
         return MyModal;
       }"
     `);

--- a/src/babel/processor-di.js
+++ b/src/babel/processor-di.js
@@ -6,15 +6,10 @@ function processReference(t, path, locationValue, state) {
 
   let shadowsOwnName = false;
   if(self) {
-    bodyPath.traverse({
-      VariableDeclaration(innerPath) {
-        innerPath.node.declarations.forEach((declaration) => {
-          if (t.isIdentifier(declaration.id) && declaration.id.name === self.name) {
-            shadowsOwnName = true;
-          }
-        });
-      },
-    });
+    const selfShadow = bodyPath.scope.getBinding(self.name);
+    if(selfShadow && selfShadow.scope===bodyPath.scope){
+      shadowsOwnName = true;
+    }
   }
   // Build list of dependencies
   // combining used imports/exports in this function block

--- a/src/babel/processor-di.js
+++ b/src/babel/processor-di.js
@@ -7,8 +7,8 @@ function processReference(t, path, locationValue, state) {
   let shadowsOwnName = false;
   if(self) {
     const selfShadow = bodyPath.scope.getBinding(self.name);
-    if(selfShadow && selfShadow.scope===bodyPath.scope){
-      shadowsOwnName = true;
+    if(selfShadow && selfShadow.scope===bodyPath.scope && selfShadow.path.node.id!==self){
+       shadowsOwnName = true;
     }
   }
   // Build list of dependencies


### PR DESCRIPTION
Consider the following code:
```tsx
function token(path) {
	let token = tokens[path];
}
```
right now it will be converted into
```tsx
function token(path, fallback) {
  const [_tokens] = (0, _reactMagneticDi.di)([_tokenNames.default], token);
  let token = _tokens[path];
}
```
However, due to `let token` we will face the temporal dead zone or "cannot access token before initialization"

----

This PR just handles this moment by removing scope when such case is detected.