### PR TITLE
Fix computed properties being renamed

### DIFF
--- a/src/babel/index.js
+++ b/src/babel/index.js
@@ -84,9 +84,15 @@ class State {
 
   addDependency(depRef) {
     depRef.findParent((p) => {
+      // avoid dynamyc object getters/setters `get [dep]() {}` to be marked as dependencies
+      // on their created scope (odd behaviour of scope.getBinding)
+      const isComputedSelfPath =
+        p.node?.computed &&
+        (depRef.parentPath === p || depRef.parentPath?.parentPath === p);
       if (
         p.isFunction() &&
-        p.parentPath?.node?.callee?.name !== INJECT_FUNCTION
+        p.parentPath?.node?.callee?.name !== INJECT_FUNCTION &&
+        !isComputedSelfPath
       ) {
         // add ref for every function scope up to the root one
         this.getValueOrInit(p).dependencyRefs.add(depRef);


### PR DESCRIPTION
If computed properties are using a dependency, the scope rename would impact them too even if it should not (I've opened an issue on Babel side too https://github.com/babel/babel/issues/16751 as I think it is somewhat unexpected)

So we added a special condition that checks for computed properties and ignores the immediate scope and reverts the renamed identifier.

Closes #92 