### PR TITLE
Skip processing if di already processed

### DIFF
--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -546,6 +546,28 @@ describe('babel plugin', () => {
     );
   });
 
+  it('should skip processing the file if di() already processed', () => {
+    const input = `
+      import { di as _di } from "react-magnetic-di";
+      import React from 'react';
+      import Modal from 'modal';
+
+      function MyComponent() {
+        const [_Modal] = _di([Modal], MyComponent);
+        return <_Modal />;
+      }
+    `;
+    expect(babel(input)).toMatchInlineSnapshot(`
+      "import { di as _di } from "react-magnetic-di";
+      import React from 'react';
+      import Modal from 'modal';
+      function MyComponent() {
+        const [_Modal] = _di([Modal], MyComponent);
+        return __jsx(_Modal, null);
+      }"
+    `);
+  });
+
   it('should add di to all top level functions', () => {
     const input = `
       import React, { memo, forwardRef } from 'react';


### PR DESCRIPTION
Sometimes it might happen that consumers mistakenly add the plugin twice (see #94). Currently we blow up as we detect a wrong `di` use, but instead we could just skip processing the file and silently continue.