### PR TITLE
Allow module mocking via jest.mock

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,7 @@ module.exports = {
     '@babel/preset-react',
     '@babel/preset-flow',
   ],
-  plugins: ['@babel/plugin-proposal-class-properties'],
+  plugins: [['@babel/plugin-proposal-class-properties', { loose: true }]],
   env: {
     test: {
       presets: [['@babel/preset-env', { targets: { node: 'current' } }]],

--- a/src/babel/processor-di.js
+++ b/src/babel/processor-di.js
@@ -107,7 +107,7 @@ function processReference(t, path, locationValue, state) {
   });
 
   // ensure we add di import
-  state.addDiImport(t);
+  state.prependDiImport(t);
 }
 
 module.exports = processReference;

--- a/src/babel/processor-inj.js
+++ b/src/babel/processor-inj.js
@@ -1,0 +1,56 @@
+const { isMatchingAny } = require('./utils');
+
+function processInjectable(t, path, state, opts) {
+  const [depPath, , configPath] = path.get('arguments');
+  if (
+    !depPath ||
+    !state?.injectIdentifier ||
+    path.get('callee').node.name !== state.injectIdentifier?.name
+  ) {
+    return;
+  }
+
+  // check if third argument is not an object with module: false
+  const moduleFlag = configPath?.node.properties?.find(
+    (n) => n.key?.name === 'module'
+  )?.value?.value;
+
+  const depName = depPath.node.name;
+  const importSource = state.imports.specifiers.get(depName);
+
+  // There are several conditions under which we should mock:
+  // - if the import source matches any defaultMockedModules regexp
+  //   and not consuming multiple exports or module flag is false
+  // - if injectable is called with explicit module: true
+  const isSourceAllowed =
+    isMatchingAny(opts.defaultMockedModules.include, importSource) &&
+    !isMatchingAny(opts.defaultMockedModules.exclude, importSource);
+
+  if ((!isSourceAllowed && !moduleFlag) || moduleFlag === false) return;
+
+  const allSpecifiers = state.imports.sources.get(importSource);
+  const remainingSpecifiers = moduleFlag
+    ? []
+    : allSpecifiers?.filter((s) => s !== depName);
+  state.imports.sources.set(importSource, remainingSpecifiers);
+
+  if (remainingSpecifiers?.length !== 0 || allSpecifiers?.length === 0) {
+    return;
+  }
+
+  const statement = t.expressionStatement(
+    t.callExpression(
+      t.memberExpression(t.identifier('jest'), t.identifier('mock')),
+      [t.stringLiteral(importSource)]
+    )
+  );
+
+  // add statement var to programPath body after all imports but before variables
+  state.programPath.get('body').some((n, i) => {
+    if (!t.isImportDeclaration(n)) {
+      state.programPath.get('body')[i].insertBefore(statement);
+      return true;
+    }
+  });
+}
+module.exports = processInjectable;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -36,6 +36,7 @@ declare export function injectable<T: Dependency>(
     target?: Function,
     global?: boolean,
     track?: boolean,
+    module?: boolean,
   |}
 ): T;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,9 +25,10 @@ declare module 'react-magnetic-di' {
 
   type Optional<T> = { [P in keyof T]-?: T[P] };
 
-  type ComponentOrFunction<Type> = Type extends ComponentType<any>
-    ? ComponentType<ComponentProps<Type>>
-    : DeepPartial<Type>;
+  type ComponentOrFunction<Type> =
+    Type extends ComponentType<any>
+      ? ComponentType<ComponentProps<Type>>
+      : DeepPartial<Type>;
 
   class DiProvider extends Component<
     {
@@ -50,6 +51,7 @@ declare module 'react-magnetic-di' {
     global?: boolean;
     target?: Function | Function[];
     track?: boolean;
+    module?: boolean;
   };
 
   function injectable<T extends Dependency>(


### PR DESCRIPTION
New babel options:

```js
// Mock injectables imports to improve test performance
// Currently supports only jest
mockModules: 'jest',
// Automatically mock injectables imports (needs mockModules set)
// For instance mock all injectables imports that are 1st party @app/foo
defaultMockedModules: ['@app/'],
```

The former, together with a new `injectable` option called `module`, allows the module of the imported variable to be mocked by jest (via `jest.mock`).

```js
const modalDi = injectable(Modal, () => null, { module: true });
```

The latter, is an experimental auto-mock behaviour, where we can automatically add jest.mock calls for all packages with an injectable defined. Should be useful to test the impact at scale (but lots of tests might fail)