### PR TITLE
Improve performance via rest argument and short circuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ In order to enforce better practices, this package exports some ESLint rules:
 | `no-restricted-injectable` | prohibits certain values from being injected: `paths: [{ name: string, importNames?: string[], message?: string }]` |
 | `sort-dependencies`        | require injectable dependencies to be sorted                                                                        |
 
-The rules are exported from `react-magnetic-di/eslint-plugin`. Unfortunately ESLint does not allow plugins that are not npm packages, so rules needs to be imported via other means for now.
+The rules are exported from `react-magnetic-di/eslint-plugin`.
 
 ## Current limitations
 
@@ -306,7 +306,7 @@ A way to check if some dependency has been tagged for injection is to use the `d
 import { debug } from 'react-magnetic-di';
 // ...
 console.log(debug(myApiFetcher));
-// It will print ['fetchApi']
+// It will print 'fetchApi'
 ```
 
 One possible reason for it to happen is that the context has been lost. Typical occurrences are async or deeply nested functions (especially in React).

--- a/src/babel/__tests__/unit.test.js
+++ b/src/babel/__tests__/unit.test.js
@@ -38,7 +38,7 @@ describe('babel plugin', () => {
       import Modal from 'modal';
       class MyComponent extends Component {
         render() {
-          const [_Modal] = _di([Modal], MyComponent);
+          const [_Modal] = _di(MyComponent, Modal);
           return __jsx(_Modal, null);
         }
       }"
@@ -57,7 +57,7 @@ describe('babel plugin', () => {
       import React from 'react';
       import Modal from 'modal';
       const MyComponent = () => {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return __jsx(_Modal, null);
       };"
     `);
@@ -77,7 +77,7 @@ describe('babel plugin', () => {
       import React from 'react';
       import Modal from 'modal';
       function MyComponent() {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return __jsx(_Modal, null);
       }"
     `);
@@ -97,7 +97,7 @@ describe('babel plugin', () => {
       import React from 'react';
       import Modal from 'modal';
       const MyComponent = function () {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return __jsx(_Modal, null);
       };"
     `);
@@ -116,7 +116,7 @@ describe('babel plugin', () => {
               "import { di as _di } from "react-magnetic-di";
               import LinkifyIt from 'linkify-it';
               const linkify = state => {
-                const [_LinkifyIt] = _di([LinkifyIt], null);
+                const [_LinkifyIt] = _di(null, LinkifyIt);
                 // cannot refer to the function location ^ as there is a local variable shadowing it
                 const linkify = new _LinkifyIt();
               };"
@@ -136,9 +136,9 @@ describe('babel plugin', () => {
         "import { di as _di } from "react-magnetic-di";
         import LinkifyIt from 'linkify-it';
         const linkify = state => {
-          const [_LinkifyIt] = _di([LinkifyIt], linkify);
+          const [_LinkifyIt] = _di(linkify, LinkifyIt);
           useEffect(() => {
-            const [_LinkifyIt2] = _di([_LinkifyIt], null);
+            const [_LinkifyIt2] = _di(null, _LinkifyIt);
             const linkify = new _LinkifyIt2();
           });
         };"
@@ -158,7 +158,7 @@ describe('babel plugin', () => {
         "import { di as _di } from "react-magnetic-di";
         import LinkifyIt from 'linkify-it';
         const linkify = state => {
-          const [_LinkifyIt] = _di([LinkifyIt], linkify);
+          const [_LinkifyIt] = _di(linkify, LinkifyIt);
           if (ff('xx')) {
             const linkify = new _LinkifyIt();
           }
@@ -182,7 +182,7 @@ describe('babel plugin', () => {
         import LinkifyIt from 'linkify-it';
         import LinkifyThat from 'linkify-it';
         const linkify = state => {
-          const [_LinkifyIt, _LinkifyThat] = _di([LinkifyIt, LinkifyThat], null);
+          const [_LinkifyIt, _LinkifyThat] = _di(null, LinkifyIt, LinkifyThat);
           const linkify = new _LinkifyIt();
           if (ff('xx')) {
             const linkify = new _LinkifyThat();
@@ -212,7 +212,7 @@ describe('babel plugin', () => {
       export const MyComponent = function () {
         const something = '';
         // comment
-        const [_Modal, _myGlobal] = di([Modal, myGlobal], MyComponent);
+        const [_Modal, _myGlobal] = di(MyComponent, Modal, myGlobal);
         return __jsx(_Modal, null);
       };"
     `);
@@ -232,7 +232,7 @@ describe('babel plugin', () => {
       import React, { forwardRef } from 'react';
       import Modal from 'modal';
       const MyComponent = /*#__PURE__*/forwardRef(() => {
-        const [_Modal] = _di([Modal], null);
+        const [_Modal] = _di(null, Modal);
         return __jsx(_Modal, null);
       });"
     `);
@@ -255,7 +255,7 @@ describe('babel plugin', () => {
       export const useModalStatus = () => true;
       export class MyStatus {}
       const MyComponent = () => {
-        const [_MyStatus, _useModalStatus] = _di([MyStatus, useModalStatus], MyComponent);
+        const [_MyStatus, _useModalStatus] = _di(MyComponent, MyStatus, useModalStatus);
         return _useModalStatus() || new _MyStatus();
       };"
     `);
@@ -276,7 +276,7 @@ describe('babel plugin', () => {
       import React from 'react';
       export default function useModalStatus() {}
       const MyComponent = () => {
-        const [_useModalStatus] = _di([useModalStatus], MyComponent);
+        const [_useModalStatus] = _di(MyComponent, useModalStatus);
         return _useModalStatus();
       };"
     `);
@@ -302,7 +302,7 @@ describe('babel plugin', () => {
       function useModalStatus() {}
       function useParentStatus() {}
       const MyComponent = () => {
-        const [_useModalStatus, _useParentStatus] = _di([useModalStatus, useParentStatus], MyComponent);
+        const [_useModalStatus, _useParentStatus] = _di(MyComponent, useModalStatus, useParentStatus);
         return _useParentStatus() || _useModalStatus();
       };
       export { useModalStatus };
@@ -334,13 +334,13 @@ describe('babel plugin', () => {
       import Modal from 'modal';
       export const useModalStatus = () => true;
       function MyComponent() {
-        const [_Modal, _useModalStatus] = _di([Modal, useModalStatus], MyComponent);
+        const [_Modal, _useModalStatus] = _di(MyComponent, Modal, useModalStatus);
         const isOpen = _useModalStatus();
         return isOpen && __jsx(_Modal, null);
       }
       class MyComponent2 extends Component {
         render() {
-          const [_Modal] = _di([Modal], MyComponent2);
+          const [_Modal] = _di(MyComponent2, Modal);
           return __jsx(_Modal, null);
         }
       }"
@@ -379,29 +379,29 @@ describe('babel plugin', () => {
       import { useEffect } from 'react';
       import { loadModal } from 'modal';
       function MyComponent() {
-        const [_loadModal, _useEffect] = _di([loadModal, useEffect], MyComponent);
+        const [_loadModal, _useEffect] = _di(MyComponent, loadModal, useEffect);
         _useEffect(() => {
-          const [_loadModal2] = _di([_loadModal], null);
+          const [_loadModal2] = _di(null, _loadModal);
           _loadModal2();
         });
       }
       const withLoad = () => {
-        const [_loadModal] = _di([loadModal], withLoad);
+        const [_loadModal] = _di(withLoad, loadModal);
         return () => {
-          const [_loadModal2] = _di([_loadModal], null);
+          const [_loadModal2] = _di(null, _loadModal);
           _loadModal2();
         };
       };
       const withAfter = () => {
-        const [_loadModal] = _di([loadModal], withAfter);
+        const [_loadModal] = _di(withAfter, loadModal);
         requestAnimationFrame(() => {
-          const [_loadModal2] = _di([_loadModal], null);
+          const [_loadModal2] = _di(null, _loadModal);
           requestAnimationFrame(() => {
-            const [_loadModal3] = _di([_loadModal2], null);
+            const [_loadModal3] = _di(null, _loadModal2);
             requestAnimationFrame(() => {
-              const [_loadModal4] = _di([_loadModal3], null);
+              const [_loadModal4] = _di(null, _loadModal3);
               requestAnimationFrame(() => {
-                const [_loadModal5] = _di([_loadModal4], null);
+                const [_loadModal5] = _di(null, _loadModal4);
                 _loadModal5();
               });
             });
@@ -435,7 +435,7 @@ describe('babel plugin', () => {
         return useModal();
       }
       export function useMyModalForced() {
-        const [_config, _useModal] = di([config, useModal], useMyModalForced);
+        const [_config, _useModal] = di(useMyModalForced, config, useModal);
         useEffect(() => {
           if (_config) return;
         });
@@ -553,7 +553,7 @@ describe('babel plugin', () => {
       import Modal from 'modal';
 
       function MyComponent() {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return <_Modal />;
       }
     `;
@@ -562,7 +562,7 @@ describe('babel plugin', () => {
       import React from 'react';
       import Modal from 'modal';
       function MyComponent() {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return __jsx(_Modal, null);
       }"
     `);
@@ -599,35 +599,35 @@ describe('babel plugin', () => {
       import React, { memo, forwardRef } from 'react';
       import { Modal } from 'modal';
       function MyComponentFn() {
-        const [_Modal] = _di([Modal], MyComponentFn);
+        const [_Modal] = _di(MyComponentFn, Modal);
         return __jsx(_Modal, null);
       }
       const MyComponentWr = /*#__PURE__*/memo(function MyComponent() {
-        const [_Modal] = _di([Modal], MyComponent);
+        const [_Modal] = _di(MyComponent, Modal);
         return __jsx(_Modal, null);
       });
       const MyComponentA = () => {
-        const [_Modal] = _di([Modal], MyComponentA);
+        const [_Modal] = _di(MyComponentA, Modal);
         return __jsx(_Modal, null);
       };
       const MyComponentAw = /*#__PURE__*/memo(() => {
-        const [_Modal] = _di([Modal], null);
+        const [_Modal] = _di(null, Modal);
         return __jsx(_Modal, null);
       });
       const MyComponentTr = true ? () => {
-        const [_Modal] = _di([Modal], null);
+        const [_Modal] = _di(null, Modal);
         return __jsx(_Modal, null);
       } : /*#__PURE__*/memo( /*#__PURE__*/forwardRef(() => {
-        const [_Modal] = _di([Modal], null);
+        const [_Modal] = _di(null, Modal);
         return __jsx(_Modal, null);
       }));
       class Foo {
         renderModal = () => {
-          const [_Modal] = _di([Modal], Foo);
+          const [_Modal] = _di(Foo, Modal);
           return __jsx(_Modal, null);
         };
         render() {
-          const [_Modal] = _di([Modal], Foo);
+          const [_Modal] = _di(Foo, Modal);
           return __jsx(_Modal, null);
         }
       }"
@@ -651,7 +651,7 @@ describe('babel plugin', () => {
       export const useModalStatus = () => true;
       const parentStatus = () => true;
       export const useStatus = () => {
-        const [_useModalStatus] = _di([useModalStatus], useStatus);
+        const [_useModalStatus] = _di(useStatus, useModalStatus);
         return _useModalStatus() || parentStatus();
       };"
     `);
@@ -736,21 +736,21 @@ describe('babel plugin', () => {
         [FOO.A]: 1,
         get [FOO.B]() {},
         get [FOO.C]() {
-          const [_FOO] = _di([FOO], null);
+          const [_FOO] = _di(null, FOO);
           return {
             get [_FOO.C]() {}
           };
         },
         get [BAR]() {
-          const [_FOO] = _di([FOO], null);
+          const [_FOO] = _di(null, FOO);
           return _FOO.C;
         },
         set [BAR](v) {
-          const [_BAR] = _di([BAR], null);
+          const [_BAR] = _di(null, BAR);
           return _BAR(v);
         },
         set [moo()](v) {
-          const [_moo] = _di([moo], null);
+          const [_moo] = _di(null, moo);
           return _moo(v);
         }
       };"
@@ -827,7 +827,7 @@ describe('babel plugin', () => {
       import { di } from 'react-magnetic-di';
       import Modal, { useModal, config } from 'modal';
       function MyComponent() {
-        const [_Modal, _config, _myGlobal, _useModal] = di([Modal, config, myGlobal, useModal], MyComponent);
+        const [_Modal, _config, _myGlobal, _useModal] = di(MyComponent, Modal, config, myGlobal, useModal);
         _useModal(_config, _myGlobal);
         return __jsx(_Modal, null);
       }"
@@ -854,9 +854,9 @@ describe('babel plugin', () => {
       var _reactMagneticDi = require("react-magnetic-di");
       var _modal = require("modal");
       function useMyModal() {
-        const [_useModal] = (0, _reactMagneticDi.di)([_modal.useModal], useMyModal);
+        const [_useModal] = (0, _reactMagneticDi.di)(useMyModal, _modal.useModal);
         return () => {
-          const [_useModal2] = (0, _reactMagneticDi.di)([_useModal], null);
+          const [_useModal2] = (0, _reactMagneticDi.di)(null, _useModal);
           return _useModal2();
         };
       }"
@@ -882,7 +882,7 @@ describe('babel plugin', () => {
         let {
           hook = useModal
         } = _ref;
-        const [_useModal] = _di([useModal], useMyModal);
+        const [_useModal] = _di(useMyModal, useModal);
         return hook();
       }"
     `);
@@ -915,10 +915,10 @@ describe('babel plugin', () => {
       import Modal, { config } from 'modal';
       function createClass() {
         var _class;
-        const [_Modal, _config] = _di([Modal, config], createClass);
+        const [_Modal, _config] = _di(createClass, Modal, config);
         return _class = class MyModal extends _Modal {
           getConfig() {
-            const [_config2] = _di([_config], MyModal);
+            const [_config2] = _di(MyModal, _config);
             return _config2;
           }
         }, _class.displayName = 'MyModal', _class;
@@ -950,9 +950,9 @@ describe('babel plugin', () => {
       "import { di } from 'react-magnetic-di';
       import { useModal } from 'modal';
       export const withModal = Comp => {
-        const [_useModal] = di([useModal], withModal);
+        const [_useModal] = di(withModal, useModal);
         return () => {
-          const [_Comp, _useModal2] = di([Comp, _useModal], null);
+          const [_Comp, _useModal2] = di(null, Comp, _useModal);
           _useModal2();
           return __jsx(_Comp, null);
         };

--- a/src/babel/processor-di.js
+++ b/src/babel/processor-di.js
@@ -53,8 +53,8 @@ function processReference(t, path, locationValue, state) {
     t.variableDeclarator(
       t.arrayPattern(elements),
       t.callExpression(t.identifier(state.diIdentifier.name), [
-        t.arrayExpression(args),
         self && !shadowsOwnName ? t.identifier(self.name) : t.nullLiteral(),
+        ...args,
       ])
     ),
   ]);
@@ -73,10 +73,10 @@ function processReference(t, path, locationValue, state) {
 
   bodyPath.scope.registerDeclaration(declarationPath);
 
-  const argsPaths = declarationPath.get(
-    'declarations.0.init.arguments.0.elements'
-  );
-  argsPaths.forEach((argPath) => {
+  const argsPaths = declarationPath.get('declarations.0.init.arguments');
+  argsPaths.forEach((argPath, idx) => {
+    // the first argument is the self reference
+    if (idx === 0) return;
     // For each argument we get the dependency variable name
     // then we rename it locally so we get a new unique identifier.
     // Then we manually revert just the argument identifier name back,

--- a/src/react/__tests__/common.js
+++ b/src/react/__tests__/common.js
@@ -6,7 +6,7 @@ export const Text = () => <text-og />;
 
 export class Label extends Component {
   render() {
-    const [_Wrapper, _Text] = di([Wrapper, Text], Label);
+    const [_Wrapper, _Text] = di(Label, Wrapper, Text);
     return (
       <label-og>
         <_Wrapper>
@@ -20,12 +20,12 @@ export class Label extends Component {
 export class Input extends Component {
   state = { value: '' };
   componentDidMount() {
-    const [_apiHandler] = di([apiHandler], Input);
+    const [_apiHandler] = di(Input, apiHandler);
     _apiHandler().then((value) => this.setState({ value }));
   }
 
   render() {
-    const [_Text] = di([Text], Input);
+    const [_Text] = di(Input, Text);
     return (
       <input-og value={this.state.value}>
         <_Text />
@@ -43,12 +43,12 @@ export const fetchApi = async () => 'fetch-og';
 export const processApiData = (v) => v + ' process-og';
 
 export function transformer(data) {
-  const [_processApiData] = di([processApiData], transformer);
+  const [_processApiData] = di(transformer, processApiData);
   return _processApiData(data);
 }
 
 export async function apiHandler() {
-  const [_fetchApi, _transformer] = di([fetchApi, transformer], apiHandler);
+  const [_fetchApi, _transformer] = di(apiHandler, fetchApi, transformer);
   const data = await _fetchApi();
   return _transformer(data);
 }

--- a/src/react/__tests__/consumer.test.js
+++ b/src/react/__tests__/consumer.test.js
@@ -6,7 +6,7 @@ describe('di', () => {
   const dependency = () => {};
 
   it('should return dependencies', () => {
-    const result = di([dependency]);
+    const result = di(null, dependency);
     expect(result).toEqual([dependency]);
   });
 });

--- a/src/react/__tests__/global.test.js
+++ b/src/react/__tests__/global.test.js
@@ -81,54 +81,6 @@ describe('globalDi', () => {
       expect(result).toEqual(['replaced']);
     });
   });
-
-  it('should be fast', () => {
-    /* prettier-ignore */
-    let a=jest.fn(), b=jest.fn(), c=jest.fn(), d=jest.fn(), e=jest.fn(), f=jest.fn(), g=jest.fn(), h=jest.fn(), i=jest.fn(), l=jest.fn(), m=jest.fn(), n=jest.fn(), o=jest.fn(), p=jest.fn(), q=jest.fn(), r=jest.fn(), s=jest.fn();
-    const testbed = () => {
-      /* prettier-ignore */
-      const [_a, _b, _c, _d, _e, _f, _g, _h, _i, _l, _m, _n, _o, _p, _q, _r, _s] = di(null, a, b, c, d, e, f, g, h, i, l, m, n, o, p, q, r, s);
-      const testbed2 = () => {
-        /* prettier-ignore */
-        const [_a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2] = di(null, _a, _b, _c, _d, _e, _f, _g, _h, _i, _l, _m, _n, _o, _p, _q, _r, _s);
-        const testbed3 = () => {
-          /* prettier-ignore */
-          const [_a3, _b3, _c3, _d3, _e3, _f3, _g3, _h3, _i3, _l3, _m3, _n3, _o3, _p3, _q3, _r3, _s3] = di(null, _a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2);
-          const testbed4 = () => {
-            /* prettier-ignore */
-            const [_a4, _b4, _c4, _d4, _e4, _f4, _g4, _h4, _i4, _l4, _m4, _n4, _o4, _p4, _q4, _r4, _s4] = di(null, _a3, _b3, _c3, _d3, _e3, _f3, _g3, _h3, _i3, _l3, _m3, _n3, _o3, _p3, _q3, _r3, _s3);
-            const testbed5 = () => {
-              /* prettier-ignore */
-              const [_a5, _b5, _c5, _d5, _e5, _f5, _g5, _h5, _i5, _l5, _m5, _n5, _o5, _p5, _q5, _r5, _s5] = di(null, _a4, _b4, _c4, _d4, _e4, _f4, _g4, _h4, _i4, _l4, _m4, _n4, _o4, _p4, _q4, _r4, _s4);
-              const testbed6 = () => {
-                /* prettier-ignore */
-                const [_a6, _b6, _c6, _d6, _e6, _f6, _g6, _h6, _i6, _l6, _m6, _n6, _o6, _p6, _q6, _r6, _s6] = di(null, _a5, _b5, _c5, _d5, _e5, _f5, _g5, _h5, _i5, _l5, _m5, _n5, _o5, _p5, _q5, _r5, _s5);
-              };
-              testbed6();
-            };
-            testbed5();
-          };
-          testbed4();
-        };
-        testbed3();
-      };
-      testbed2();
-    };
-
-    // warmup
-    testbed();
-
-    let startTime = performance.now();
-    testbed();
-    console.log('plain', (performance.now() - startTime) * 100);
-    // const result = di([dependency]);
-    // expect(result).toEqual([dependency]);
-    runWithDi(() => {
-      startTime = performance.now();
-      testbed();
-      console.log('runWithDi', (performance.now() - startTime) * 100);
-    }, [injectable(a, jest.fn())]);
-  });
 });
 
 describe('runWithDi', () => {

--- a/src/react/__tests__/global.test.js
+++ b/src/react/__tests__/global.test.js
@@ -77,9 +77,57 @@ describe('globalDi', () => {
 
     test.each(cases)('should hanlde dependency value %p', (value) => {
       globalDi.use([injectable(value, 'replaced')]);
-      const result = di([value]);
+      const result = di(null, value);
       expect(result).toEqual(['replaced']);
     });
+  });
+
+  it('should be fast', () => {
+    /* prettier-ignore */
+    let a=jest.fn(), b=jest.fn(), c=jest.fn(), d=jest.fn(), e=jest.fn(), f=jest.fn(), g=jest.fn(), h=jest.fn(), i=jest.fn(), l=jest.fn(), m=jest.fn(), n=jest.fn(), o=jest.fn(), p=jest.fn(), q=jest.fn(), r=jest.fn(), s=jest.fn();
+    const testbed = () => {
+      /* prettier-ignore */
+      const [_a, _b, _c, _d, _e, _f, _g, _h, _i, _l, _m, _n, _o, _p, _q, _r, _s] = di(null, a, b, c, d, e, f, g, h, i, l, m, n, o, p, q, r, s);
+      const testbed2 = () => {
+        /* prettier-ignore */
+        const [_a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2] = di(null, _a, _b, _c, _d, _e, _f, _g, _h, _i, _l, _m, _n, _o, _p, _q, _r, _s);
+        const testbed3 = () => {
+          /* prettier-ignore */
+          const [_a3, _b3, _c3, _d3, _e3, _f3, _g3, _h3, _i3, _l3, _m3, _n3, _o3, _p3, _q3, _r3, _s3] = di(null, _a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2);
+          const testbed4 = () => {
+            /* prettier-ignore */
+            const [_a4, _b4, _c4, _d4, _e4, _f4, _g4, _h4, _i4, _l4, _m4, _n4, _o4, _p4, _q4, _r4, _s4] = di(null, _a3, _b3, _c3, _d3, _e3, _f3, _g3, _h3, _i3, _l3, _m3, _n3, _o3, _p3, _q3, _r3, _s3);
+            const testbed5 = () => {
+              /* prettier-ignore */
+              const [_a5, _b5, _c5, _d5, _e5, _f5, _g5, _h5, _i5, _l5, _m5, _n5, _o5, _p5, _q5, _r5, _s5] = di(null, _a4, _b4, _c4, _d4, _e4, _f4, _g4, _h4, _i4, _l4, _m4, _n4, _o4, _p4, _q4, _r4, _s4);
+              const testbed6 = () => {
+                /* prettier-ignore */
+                const [_a6, _b6, _c6, _d6, _e6, _f6, _g6, _h6, _i6, _l6, _m6, _n6, _o6, _p6, _q6, _r6, _s6] = di(null, _a5, _b5, _c5, _d5, _e5, _f5, _g5, _h5, _i5, _l5, _m5, _n5, _o5, _p5, _q5, _r5, _s5);
+              };
+              testbed6();
+            };
+            testbed5();
+          };
+          testbed4();
+        };
+        testbed3();
+      };
+      testbed2();
+    };
+
+    // warmup
+    testbed();
+
+    let startTime = performance.now();
+    testbed();
+    console.log('plain', (performance.now() - startTime) * 100);
+    // const result = di([dependency]);
+    // expect(result).toEqual([dependency]);
+    runWithDi(() => {
+      startTime = performance.now();
+      testbed();
+      console.log('runWithDi', (performance.now() - startTime) * 100);
+    }, [injectable(a, jest.fn())]);
   });
 });
 

--- a/src/react/__tests__/provider.test.js
+++ b/src/react/__tests__/provider.test.js
@@ -78,12 +78,12 @@ describe('DiProvider', () => {
         </DiProvider>
       );
       const { getDependencies } = children.mock.calls[0][0];
-      // when di([...], MyComponent)
+      // when di(MyComponent, ...)
       expect(getDependencies([Text, Button], MyComponent)).toEqual([
         TextDi,
         Button,
       ]);
-      // when di([...], null)
+      // when di(null, ...)
       expect(getDependencies([Text, Button], null)).toEqual([Text, Button]);
     });
 
@@ -111,7 +111,7 @@ describe('DiProvider', () => {
       );
 
       render(
-        <DiProvider use={[TextDi, TextDi2]}>
+        <DiProvider use={[TextDi]}>
           <WrappedConsumer />
         </DiProvider>
       );
@@ -219,7 +219,7 @@ describe('DiProvider', () => {
     const cases = [1, 'string', null, Symbol('test'), function () {}];
     test.each(cases)('should hanlde dependency value %p', (value) => {
       const spy = jest.fn();
-      const Child = () => spy(di([value]));
+      const Child = () => spy(di(null, value));
       render(
         <DiProvider use={[injectable(value, 'replaced')]}>
           <Child />

--- a/src/react/consumer.js
+++ b/src/react/consumer.js
@@ -1,16 +1,13 @@
 import { Context } from './context';
 import { globalDi } from './global';
 
-export function di(deps, target) {
-  // check if babel plugin has been added othrewise this is a noop
-  if (Array.isArray(deps)) {
-    // Read context and grab all the dependencies override Providers in the tree
-    const { getDependencies } =
-      // grab value from alt renderer (eg react-test-renderer)
-      (Context._currentRenderer2 && Context._currentValue2) ||
-      // grab value from default renderer
-      Context._currentValue ||
-      globalDi;
-    return getDependencies(deps, target);
-  }
+export function di(target, ...deps) {
+  // Read context and grab all the dependencies override Providers in the tree
+  const { getDependencies } =
+    // grab value from alt renderer (eg react-test-renderer)
+    (Context._currentRenderer2 && Context._currentValue2) ||
+    // grab value from default renderer
+    Context._currentValue ||
+    globalDi;
+  return getDependencies(deps, target);
 }

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -9,11 +9,18 @@ const replacementMap = new Map();
 
 export const globalDi = {
   getDependencies(realDeps, targetChild) {
-    if (!replacementMap.size) return realDeps;
-    return realDeps.map((dep) => {
-      const replacedInj = findInjectable(replacementMap, dep, targetChild);
-      return replacedInj ? replacedInj.value : dep;
-    });
+    if (replacementMap.size) {
+      for (let i = 0; i < realDeps.length; i++) {
+        const replacedInj = findInjectable(
+          replacementMap,
+          realDeps[i],
+          targetChild
+        );
+        if (replacedInj) realDeps[i] = replacedInj.value;
+      }
+    }
+
+    return realDeps;
   },
 
   use(injs) {

--- a/src/react/global.js
+++ b/src/react/global.js
@@ -9,6 +9,7 @@ const replacementMap = new Map();
 
 export const globalDi = {
   getDependencies(realDeps, targetChild) {
+    if (!replacementMap.size) return realDeps;
     return realDeps.map((dep) => {
       const replacedInj = findInjectable(replacementMap, dep, targetChild);
       return replacedInj ? replacedInj.value : dep;

--- a/src/react/injectable.js
+++ b/src/react/injectable.js
@@ -29,7 +29,7 @@ export function injectable(
   diRegistry.set(impl, {
     value: implementation,
     from,
-    targets: target && (Array.isArray(target) ? target : [target]),
+    targets: target && new WeakSet(Array.isArray(target) ? target : [target]),
     track,
     global,
     cause: track

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -45,18 +45,21 @@ export function getDisplayName(Comp, wrapper = '') {
 
 export function debug(fn) {
   const source = fn.toString();
-  const [, args] = source.match(/const \[[^\]]+\] = .*di.*\(\[([^\]]+)/) || [];
+  const [, args] =
+    source.match(/const \[[^\]]+\] = .*di.*\(\w+[,\s]+([^)]+)/) || [];
   return args;
 }
 
 export function findInjectable(replacementMap, dep, targetChild) {
-  const injectables = replacementMap.get(dep) || new Set();
+  const injectables = replacementMap.get(dep);
+  if (!injectables) return null;
+
   // loop all injectables for the dep, with targeted ones preferred
   let anyCandidate = null;
   let targetCandidate = null;
   for (const inj of injectables) {
     if (!inj.targets) anyCandidate = inj;
-    if (inj.targets?.includes(targetChild)) targetCandidate = inj;
+    if (inj.targets?.has(targetChild)) targetCandidate = inj;
   }
   const candidate = targetCandidate || anyCandidate;
   stats.track(candidate);


### PR DESCRIPTION
- instead of creating an array for the dependencies, use plain arguments as `fn.call` does, reducing memory and processing time
- directly mutate the rest arguments to avoid creating new arrays 
- check global replacements size to avoid any processing if none is set 
- use `WeakSet` to check if targets matches