### PR TITLE
Fix cause bicoming null if reset straight away

### DIFF
--- a/src/react/__tests__/stats.test.js
+++ b/src/react/__tests__/stats.test.js
@@ -63,6 +63,20 @@ describe('stats', () => {
       );
       expect(stats.unused()).toHaveLength(0);
     });
+
+    it('should provide an error with the cause information', () => {
+      const deps = [TextDi, WrapperDi, processApiDataDi];
+      render(
+        <DiProvider use={deps}>
+          <Label />
+        </DiProvider>
+      );
+      expect(stats.unused()).toHaveLength(1);
+      expect(stats.unused()[0].error().cause).toBeInstanceOf(Error);
+      expect(stats.unused()[0].error().cause.message).toContain(
+        'Injectable created but not used'
+      );
+    });
   });
 
   describe('with runWithDi', () => {

--- a/src/react/stats.js
+++ b/src/react/stats.js
@@ -7,20 +7,18 @@ const createState = () => ({
 export const stats = {
   state: createState(),
 
-  set(injObj) {
+  set(inj) {
     // allow injectable override without flagging as unused
     for (let unusedInj of this.state.unused.keys())
-      if (unusedInj.from === injObj.from) this.state.unused.delete(unusedInj);
+      if (unusedInj.from === inj.from) this.state.unused.delete(unusedInj);
 
     this.state.unused.set(
-      injObj,
+      inj,
       new Error(
-        `Unused "di" injectable: ${injObj.value?.displayName || injObj.value}.`,
-        { cause: injObj.cause }
+        `Unused "di" injectable: ${inj.value?.displayName || inj.value}.`,
+        { cause: inj.cause }
       )
     );
-    // reset to avoid potential memory leaks via stack traces
-    injObj.cause = null;
   },
 
   track(inj) {
@@ -28,6 +26,8 @@ export const stats = {
     this.state.unused.delete(inj);
     this.state.used.add(inj);
     this.state.provided.add(inj.from);
+    // reset to avoid potential memory leaks via stack traces
+    inj.cause = null;
   },
 
   reset() {


### PR DESCRIPTION
Not sure when this regression happened, but in node 20 setting `cause` to `null` on the injectable object also makes the error's `cause` property to become `null`. Unless there is something that I'm not seeing, could not find a way to retain the value (local assignments, `structuredClone`, explicit stack reference, ...). 

Given we want to keep the error only when injectables are not used, it was easy enough to move the cleanup when we `track` the usage so it is persisted only otherwise.