### PR TITLE
fix: dont use promise.finally as it creates new unhandled promise rejection

### DIFF
--- a/src/react/global.js
+++ b/src/react/global.js
@@ -61,10 +61,10 @@ export function runWithDi(thunk, deps) {
     if (
       result &&
       typeof result === 'object' &&
-      typeof result.then === 'function' &&
-      typeof result.finally === 'function'
+      typeof result.then === 'function'
     ) {
-      result.finally(globalDi.clear);
+      // dont use finally as it "multiplies" rejected promises
+      result.then(globalDi.clear, globalDi.clear);
     } else {
       globalDi.clear();
     }


### PR DESCRIPTION
In very short - `.finally` will create another promise and if the test function did fail - that would be another rejected promise, and the unhandled one. That would lead test to the failure somewhere afterEach

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally

> unlike Promise.reject(3).then(() => {}, () => 88), which returns a promise eventually fulfilled with the value 88, Promise.reject(3).finally(() => 88) returns a promise eventually rejected with the reason 3.

