### PR TITLE
feat: add React 19 support to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.0.0",
-    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
     "eslint": {


### PR DESCRIPTION
## Description
This PR adds React 19 support to peer dependencies.

## Problem
The package currently specifies peer dependency for React `^16.9.0 || ^17.0.0 || ^18.0.0`, which doesn't include React 19. This causes dependency resolution errors when trying to use the package with React 19.

### Error Message
```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error peer react@"^16.9.0 || ^17.0.0 || ^18.0.0" from react-magnetic-di@3.2.4
npm error Found: react@19.2.1
```

## Solution
Updated `peerDependencies` in `package.json` to include React 19:
```json
"react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
```

## Environment
- react-magnetic-di version: 3.2.4
- React version: 19.2.1